### PR TITLE
PR 2: Database Connection

### DIFF
--- a/adk_agent_sim/persistence/__init__.py
+++ b/adk_agent_sim/persistence/__init__.py
@@ -5,6 +5,7 @@ for storing SimulatorSession and SessionEvent protos using the Promoted Field
 pattern.
 """
 
+from adk_agent_sim.persistence.database import Database
 from adk_agent_sim.persistence.schema import events, metadata, sessions
 
-__all__ = ["events", "metadata", "sessions"]
+__all__ = ["Database", "events", "metadata", "sessions"]

--- a/adk_agent_sim/persistence/database.py
+++ b/adk_agent_sim/persistence/database.py
@@ -1,0 +1,76 @@
+"""Async database connection manager using the databases library.
+
+Provides lifecycle management for database connections and table creation
+using SQLAlchemy Core metadata definitions.
+"""
+
+from typing import Any
+
+from databases import Database as DatabaseClient
+from sqlalchemy import create_engine
+from sqlalchemy.schema import CreateIndex, CreateTable
+
+from adk_agent_sim.persistence.schema import metadata
+
+DEFAULT_DATABASE_URL = "sqlite+aiosqlite:///./simulator.db"
+
+
+class Database:
+  """Async database connection manager.
+
+  Manages connection lifecycle and provides table creation utilities.
+  Uses the `databases` library for async database operations.
+  """
+
+  def __init__(self, url: str | None = None) -> None:
+    """Initialize database connection manager.
+
+    Args:
+        url: Database URL. Defaults to SQLite file at ./simulator.db.
+    """
+    self.url = url or DEFAULT_DATABASE_URL
+    self._client = DatabaseClient(self.url)
+
+  @property
+  def is_connected(self) -> bool:
+    """Check if database is currently connected."""
+    return self._client.is_connected
+
+  async def connect(self) -> None:
+    """Establish database connection."""
+    await self._client.connect()
+
+  async def disconnect(self) -> None:
+    """Close database connection."""
+    await self._client.disconnect()
+
+  async def create_tables(self) -> None:
+    """Create all tables defined in the schema metadata."""
+    # Use sync engine only for DDL compilation (not execution)
+    sync_url = self.url.replace("sqlite+aiosqlite", "sqlite").split("?")[0]
+    engine = create_engine(sync_url)
+
+    # Create tables (use IF NOT EXISTS for idempotency)
+    for table in metadata.sorted_tables:
+      ddl = str(CreateTable(table, if_not_exists=True).compile(engine))
+      await self._client.execute(ddl)  # pyright: ignore[reportUnknownMemberType]
+
+    # Create indexes (use IF NOT EXISTS for idempotency)
+    for table in metadata.sorted_tables:
+      for index in table.indexes:
+        ddl = str(CreateIndex(index, if_not_exists=True).compile(engine))
+        await self._client.execute(ddl)  # pyright: ignore[reportUnknownMemberType]
+
+    engine.dispose()
+
+  async def fetch_all(self, query: str) -> list[dict[str, Any]]:
+    """Execute a query and fetch all results.
+
+    Args:
+        query: SQL query string.
+
+    Returns:
+        List of row dictionaries.
+    """
+    rows = await self._client.fetch_all(query)  # pyright: ignore[reportUnknownMemberType]
+    return [dict(row._mapping) for row in rows]  # pyright: ignore[reportUnknownMemberType]

--- a/tests/unit/persistence/__init__.py
+++ b/tests/unit/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the persistence layer."""

--- a/tests/unit/persistence/test_database.py
+++ b/tests/unit/persistence/test_database.py
@@ -1,0 +1,71 @@
+"""Tests for the Database connection manager."""
+
+import pytest
+
+from adk_agent_sim.persistence import metadata
+from adk_agent_sim.persistence.database import DEFAULT_DATABASE_URL, Database
+
+# In-memory SQLite URL with shared cache for testing
+# (shared cache is required for in-memory DBs with the databases library)
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:?cache=shared"
+
+
+class TestDatabaseConnection:
+  """Tests for database connection lifecycle."""
+
+  @pytest.mark.asyncio
+  async def test_connect_and_disconnect(self) -> None:
+    """Database can connect and disconnect successfully."""
+    db = Database(TEST_DB_URL)
+    assert not db.is_connected
+
+    await db.connect()
+    assert db.is_connected
+
+    await db.disconnect()
+    assert not db.is_connected
+
+  @pytest.mark.asyncio
+  async def test_default_url(self) -> None:
+    """Database uses default SQLite URL when none provided."""
+    db = Database()
+    assert db.url == DEFAULT_DATABASE_URL
+
+
+class TestDatabaseTables:
+  """Tests for table creation."""
+
+  @pytest.mark.asyncio
+  async def test_create_tables(self) -> None:
+    """create_tables creates all schema tables."""
+    db = Database(TEST_DB_URL)
+    await db.connect()
+    await db.create_tables()
+
+    # Verify tables exist by querying sqlite_master
+    query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    rows = await db.fetch_all(query)
+    table_names = [row["name"] for row in rows]
+
+    # Should have our tables (events and sessions)
+    assert "sessions" in table_names
+    assert "events" in table_names
+
+    await db.disconnect()
+
+  @pytest.mark.asyncio
+  async def test_tables_match_schema_metadata(self) -> None:
+    """Created tables match the schema metadata definitions."""
+    db = Database(TEST_DB_URL)
+    await db.connect()
+    await db.create_tables()
+
+    # Verify all metadata tables were created
+    expected_tables = set(metadata.tables.keys())
+    query = "SELECT name FROM sqlite_master WHERE type='table'"
+    rows = await db.fetch_all(query)
+    actual_tables = {row["name"] for row in rows}
+
+    assert expected_tables.issubset(actual_tables)
+
+    await db.disconnect()


### PR DESCRIPTION
## Summary
Async database connection manager using the `databases` library for connection lifecycle and table creation.

## Tasks Completed
- [x] T005: Create `Database` connection class with `connect()` and `disconnect()`
- [x] T006: Implement `create_tables()` using SQLAlchemy metadata
- [x] T007: Add database URL configuration (default: sqlite+aiosqlite:///./simulator.db)
- [x] T008: Add database connection tests

## User Stories
- US3: Session Persistence

## Testing
- Presubmit passed locally
- 4 new tests using in-memory SQLite
- Awaiting CI verification

## Line Count
~150 lines (within 100-200 LOC limit)