### PR TITLE
PR 13: SimulatorService.create_session RPC

### DIFF
--- a/adk_agent_sim/server/services/simulator_service.py
+++ b/adk_agent_sim/server/services/simulator_service.py
@@ -5,97 +5,51 @@ validation of agent workflows by intercepting LLM calls and routing them to
 a web UI for manual decision-making.
 """
 
+from typing import TYPE_CHECKING
+
+from adk_agent_sim.generated.adksim.v1 import (
+  CreateSessionResponse,
+  SimulatorServiceBase,
+)
 from adk_agent_sim.server.logging import get_logger
 
-# Import generated protos once available
-# from adk_agent_sim.generated.adksim.v1 import (
-#     SimulatorServiceBase,
-#     CreateSessionRequest,
-#     CreateSessionResponse,
-#     SubscribeRequest,
-#     SessionEvent,
-#     SubmitRequestRequest,
-#     SubmitRequestResponse,
-#     SubmitDecisionRequest,
-#     SubmitDecisionResponse,
-#     ListSessionsRequest,
-#     ListSessionsResponse,
-# )
+if TYPE_CHECKING:
+  from adk_agent_sim.generated.adksim.v1 import CreateSessionRequest
+  from adk_agent_sim.server.session_manager import SessionManager
 
 logger = get_logger("simulator_service")
 
 
-class SimulatorService:
+class SimulatorService(SimulatorServiceBase):
   """gRPC service for the ADK Agent Simulator.
 
   Implements the SimulatorService proto definition, providing:
   - Session management (create, list)
   - Event streaming (subscribe to session events)
   - Request/Decision submission (Plugin -> UI -> Plugin flow)
-
-  TODO: Inherit from SimulatorServiceBase once protos are generated.
   """
 
-  def __init__(self) -> None:
-    """Initialize the SimulatorService."""
+  def __init__(self, session_manager: SessionManager) -> None:
+    """Initialize the SimulatorService.
+
+    Args:
+        session_manager: SessionManager instance.
+    """
+    self._session_manager = session_manager
     logger.info("SimulatorService initialized")
 
-  async def create_session(self, request: object) -> object:
+  async def create_session(
+    self, create_session_request: CreateSessionRequest
+  ) -> CreateSessionResponse:
     """Create a new simulation session.
 
     Args:
-        request: CreateSessionRequest with optional description.
+        create_session_request: CreateSessionRequest with optional description.
 
     Returns:
         CreateSessionResponse containing the created Session.
     """
-    # TODO: Implement session creation with persistence
-    raise NotImplementedError("create_session not yet implemented")
-
-  async def subscribe(self, request: object) -> object:
-    """Subscribe to a session's event stream.
-
-    Args:
-        request: SubscribeRequest with session_id and client_id.
-
-    Yields:
-        SessionEvent objects as they occur.
-    """
-    # TODO: Implement event streaming with replay
-    raise NotImplementedError("subscribe not yet implemented")
-
-  async def submit_request(self, request: object) -> object:
-    """Submit an intercepted LLM request.
-
-    Args:
-        request: SubmitRequestRequest with the intercepted LLM request.
-
-    Returns:
-        SubmitRequestResponse with the assigned event_id.
-    """
-    # TODO: Implement request submission with broadcasting
-    raise NotImplementedError("submit_request not yet implemented")
-
-  async def submit_decision(self, request: object) -> object:
-    """Submit a human decision (response).
-
-    Args:
-        request: SubmitDecisionRequest with the human's response.
-
-    Returns:
-        SubmitDecisionResponse with the assigned event_id.
-    """
-    # TODO: Implement decision submission with broadcasting
-    raise NotImplementedError("submit_decision not yet implemented")
-
-  async def list_sessions(self, request: object) -> object:
-    """List all historical sessions.
-
-    Args:
-        request: ListSessionsRequest with pagination parameters.
-
-    Returns:
-        ListSessionsResponse with sessions and pagination token.
-    """
-    # TODO: Implement session listing from persistence
-    raise NotImplementedError("list_sessions not yet implemented")
+    session = await self._session_manager.create_session(
+      description=create_session_request.description
+    )
+    return CreateSessionResponse(session=session)

--- a/adk_agent_sim/settings.py
+++ b/adk_agent_sim/settings.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
   log_level: str = "INFO"
+  database_url: str = "sqlite+aiosqlite:///adk_agent_sim.db"
 
   model_config = SettingsConfigDict(
     env_file=(".env", ".env.secrets"),

--- a/tests/unit/server/test_session_manager.py
+++ b/tests/unit/server/test_session_manager.py
@@ -1,15 +1,12 @@
 """Tests for SessionManager."""
 
 import uuid
-from typing import TYPE_CHECKING
 
 import pytest
 
 from adk_agent_sim.generated.adksim.v1 import SimulatorSession
-
-if TYPE_CHECKING:
-  from adk_agent_sim.server.session_manager import SessionManager
-  from tests.fixtures import FakeEventRepository, FakeSessionRepository
+from adk_agent_sim.server.session_manager import SessionManager
+from tests.fixtures import FakeEventRepository, FakeSessionRepository
 
 
 class TestSessionManager:
@@ -17,9 +14,9 @@ class TestSessionManager:
 
   def test_initialization(
     self,
-    manager: "SessionManager",  # noqa: UP037
-    session_repo: "FakeSessionRepository",  # noqa: UP037
-    event_repo: "FakeEventRepository",  # noqa: UP037
+    manager: SessionManager,
+    session_repo: FakeSessionRepository,
+    event_repo: FakeEventRepository,
   ) -> None:
     """Test that SessionManager can be initialized with repositories."""
     assert manager is not None

--- a/tests/unit/server/test_simulator_service.py
+++ b/tests/unit/server/test_simulator_service.py
@@ -1,28 +1,32 @@
 """Tests for SimulatorService."""
 
+from typing import TYPE_CHECKING
+
 import pytest
 
+from adk_agent_sim.generated.adksim.v1 import CreateSessionRequest
 from adk_agent_sim.server.services.simulator_service import SimulatorService
+
+if TYPE_CHECKING:
+  from adk_agent_sim.server.session_manager import SessionManager
 
 
 class TestSimulatorService:
   """Test suite for SimulatorService."""
 
-  def test_service_initialization(self) -> None:
+  def test_service_initialization(self, manager: SessionManager) -> None:
     """Test that SimulatorService can be instantiated."""
-    service = SimulatorService()
+    service = SimulatorService(session_manager=manager)
     assert service is not None
 
   @pytest.mark.asyncio
-  async def test_create_session_not_implemented(self) -> None:
-    """Test that create_session raises NotImplementedError."""
-    service = SimulatorService()
-    with pytest.raises(NotImplementedError):
-      await service.create_session({})
+  async def test_create_session_success(self, manager: SessionManager) -> None:
+    """Test that create_session creates a session successfully."""
+    service = SimulatorService(session_manager=manager)
+    request = CreateSessionRequest(description="test session")
 
-  @pytest.mark.asyncio
-  async def test_list_sessions_not_implemented(self) -> None:
-    """Test that list_sessions raises NotImplementedError."""
-    service = SimulatorService()
-    with pytest.raises(NotImplementedError):
-      await service.list_sessions({})
+    response = await service.create_session(request)
+
+    assert response.session is not None
+    assert response.session.description == "test session"
+    assert response.session.id is not None


### PR DESCRIPTION
## Summary
Implement create_session RPC in SimulatorService.

## Tasks Completed
- [x] T046: Enhance SimulatorService with SessionManager dependency injection
- [x] T047: Implement create_session delegating to SessionManager
- [x] T048: Add create_session RPC tests

## Testing
- Presubmit passed
