### PR TITLE
PR 14: SimulatorService.list_sessions RPC

### DIFF
--- a/adk_agent_sim/persistence/__init__.py
+++ b/adk_agent_sim/persistence/__init__.py
@@ -6,13 +6,14 @@ pattern.
 """
 
 from adk_agent_sim.persistence.core import (
+  PaginatedSessions,
   SessionEventRepository,
   SessionRepositoryProtocol,
 )
 from adk_agent_sim.persistence.database import Database
 from adk_agent_sim.persistence.event_repo import EventRepository
 from adk_agent_sim.persistence.schema import events, metadata, sessions
-from adk_agent_sim.persistence.session_repo import PaginatedSessions, SessionRepository
+from adk_agent_sim.persistence.session_repo import SessionRepository
 
 __all__ = [
   "Database",

--- a/adk_agent_sim/persistence/core.py
+++ b/adk_agent_sim/persistence/core.py
@@ -5,6 +5,7 @@ This module defines repository protocols used by higher-level components
 concrete persistence implementations.
 """
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from adk_agent_sim.generated.adksim.v1 import SessionStatus
@@ -13,16 +14,31 @@ if TYPE_CHECKING:
   from adk_agent_sim.generated.adksim.v1 import SessionEvent, SimulatorSession
 
 
+@dataclass
+class PaginatedSessions:
+  """Result of a paginated session query."""
+
+  sessions: list["SimulatorSession"]  # noqa: UP037
+  """List of sessions for the current page."""
+
+  next_page_token: str | None
+  """Token to fetch the next page, or None if this is the last page."""
+
+
 class SessionRepositoryProtocol(Protocol):
   """Protocol for session repository operations."""
 
   async def create(
     self,
-    session: SimulatorSession,
+    session: "SimulatorSession",  # noqa: UP037
     status: SessionStatus = SessionStatus.ACTIVE,
-  ) -> SimulatorSession: ...
+  ) -> "SimulatorSession": ...  # noqa: UP037
 
-  async def get_by_id(self, session_id: str) -> SimulatorSession | None: ...
+  async def get_by_id(self, session_id: str) -> "SimulatorSession | None": ...  # noqa: UP037
+
+  async def list_all(
+    self, page_size: int, page_token: str | None
+  ) -> PaginatedSessions: ...
 
 
 class SessionEventRepository(Protocol):

--- a/adk_agent_sim/persistence/session_repo.py
+++ b/adk_agent_sim/persistence/session_repo.py
@@ -5,28 +5,17 @@ queryable fields extracted into SQL columns for efficient filtering.
 """
 
 import base64
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 
 from adk_agent_sim.generated.adksim.v1 import SessionStatus
+from adk_agent_sim.persistence.core import PaginatedSessions
 from adk_agent_sim.persistence.schema import sessions
 
 if TYPE_CHECKING:
   from adk_agent_sim.generated.adksim.v1 import SimulatorSession
   from adk_agent_sim.persistence.database import Database
-
-
-@dataclass
-class PaginatedSessions:
-  """Result of a paginated session query."""
-
-  sessions: list[SimulatorSession]
-  """List of sessions for the current page."""
-
-  next_page_token: str | None
-  """Token to fetch the next page, or None if this is the last page."""
 
 
 class SessionRepository:

--- a/adk_agent_sim/server/services/simulator_service.py
+++ b/adk_agent_sim/server/services/simulator_service.py
@@ -9,12 +9,16 @@ from typing import TYPE_CHECKING
 
 from adk_agent_sim.generated.adksim.v1 import (
   CreateSessionResponse,
+  ListSessionsResponse,
   SimulatorServiceBase,
 )
 from adk_agent_sim.server.logging import get_logger
 
 if TYPE_CHECKING:
-  from adk_agent_sim.generated.adksim.v1 import CreateSessionRequest
+  from adk_agent_sim.generated.adksim.v1 import (
+    CreateSessionRequest,
+    ListSessionsRequest,
+  )
   from adk_agent_sim.server.session_manager import SessionManager
 
 logger = get_logger("simulator_service")
@@ -53,3 +57,22 @@ class SimulatorService(SimulatorServiceBase):
       description=create_session_request.description
     )
     return CreateSessionResponse(session=session)
+
+  async def list_sessions(
+    self,
+    list_sessions_request: "ListSessionsRequest",  # noqa: UP037
+  ) -> ListSessionsResponse:
+    """List sessions with pagination.
+
+    Args:
+        list_sessions_request: ListSessionsRequest with page_size and page_token.
+
+    Returns:
+        ListSessionsResponse containing the list of sessions and next_page_token.
+    """
+    result = await self._session_manager.list_sessions(
+      list_sessions_request.page_size, list_sessions_request.page_token
+    )
+    return ListSessionsResponse(
+      sessions=result.sessions, next_page_token=result.next_page_token or ""
+    )

--- a/adk_agent_sim/server/session_manager.py
+++ b/adk_agent_sim/server/session_manager.py
@@ -13,6 +13,7 @@ from adk_agent_sim.generated.adksim.v1 import SimulatorSession
 
 if TYPE_CHECKING:
   from adk_agent_sim.persistence import (
+    PaginatedSessions,
     SessionEventRepository,
     SessionRepositoryProtocol,
   )
@@ -112,3 +113,17 @@ class SessionManager:
       self._active_sessions[session_id] = session
 
     return session
+
+  async def list_sessions(
+    self, page_size: int, page_token: str | None
+  ) -> "PaginatedSessions":  # noqa: UP037
+    """List sessions with pagination.
+
+    Args:
+        page_size: Maximum number of sessions to return.
+        page_token: Token for the next page, or None for the first page.
+
+    Returns:
+        PaginatedSessions containing the list of sessions and next page token.
+    """
+    return await self._session_repo.list_all(page_size, page_token)

--- a/tests/unit/server/test_simulator_service.py
+++ b/tests/unit/server/test_simulator_service.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from adk_agent_sim.generated.adksim.v1 import CreateSessionRequest
+from adk_agent_sim.generated.adksim.v1 import CreateSessionRequest, ListSessionsRequest
 from adk_agent_sim.server.services.simulator_service import SimulatorService
 
 if TYPE_CHECKING:
@@ -30,3 +30,45 @@ class TestSimulatorService:
     assert response.session is not None
     assert response.session.description == "test session"
     assert response.session.id is not None
+
+  @pytest.mark.asyncio
+  async def test_list_sessions_success(self, manager: SessionManager) -> None:
+    """Test that list_sessions returns sessions successfully."""
+    service = SimulatorService(session_manager=manager)
+    # Create some sessions
+    await manager.create_session("session 1")
+    await manager.create_session("session 2")
+
+    request = ListSessionsRequest(page_size=10)
+    response = await service.list_sessions(request)
+
+    assert len(response.sessions) == 2
+    assert response.sessions[0].description == "session 2"  # Most recent first
+    assert response.sessions[1].description == "session 1"
+    assert not response.next_page_token
+
+  @pytest.mark.asyncio
+  async def test_list_sessions_pagination(self, manager: SessionManager) -> None:
+    """Test that list_sessions handles pagination correctly."""
+    service = SimulatorService(session_manager=manager)
+    # Create 3 sessions
+    await manager.create_session("session 1")
+    await manager.create_session("session 2")
+    await manager.create_session("session 3")
+
+    # Request page size 2
+    request = ListSessionsRequest(page_size=2)
+    response = await service.list_sessions(request)
+
+    assert len(response.sessions) == 2
+    assert response.sessions[0].description == "session 3"
+    assert response.sessions[1].description == "session 2"
+    assert response.next_page_token
+
+    # Request next page
+    request = ListSessionsRequest(page_size=2, page_token=response.next_page_token)
+    response = await service.list_sessions(request)
+
+    assert len(response.sessions) == 1
+    assert response.sessions[0].description == "session 1"
+    assert not response.next_page_token


### PR DESCRIPTION
## Summary
Implement list_sessions RPC in SimulatorService.

## Tasks Completed
- [x] T049: Implement list_sessions with pagination
- [x] T050: Add list_sessions RPC tests
- [x] Move PaginatedSessions to core.py
- [x] Add list_all to SessionRepositoryProtocol

## Testing
- Presubmit passed
