### PR TITLE
phase/2/feat/4/event broadcaster

### DIFF
--- a/adk_agent_sim/server/broadcaster.py
+++ b/adk_agent_sim/server/broadcaster.py
@@ -3,6 +3,10 @@
 Provides a pub/sub mechanism for broadcasting session events to
 multiple subscribers. Each session has its own set of subscribers,
 and events are broadcast to all subscribers for that session.
+
+Includes per-session locking to ensure atomic history retrieval
+and subscriber registration, preventing race conditions where events
+could be missed during the subscription process.
 """
 
 import asyncio
@@ -10,7 +14,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-  from collections.abc import AsyncIterator
+  from collections.abc import AsyncIterator, Awaitable, Callable
 
   from adk_agent_sim.generated.adksim.v1 import SessionEvent
 
@@ -18,18 +22,22 @@ if TYPE_CHECKING:
 class EventBroadcaster:
   """Broadcasts session events to all subscribers for a session.
 
-  Manages per-session subscriber queues. When an event is broadcast,
-  it is pushed to all subscriber queues for that session. Each subscriber
-  receives events via an async iterator.
+  Manages per-session subscriber queues with locking to prevent race
+  conditions. When subscribing, history retrieval and queue registration
+  happen atomically relative to broadcasts, ensuring no events are missed.
 
   Attributes:
       _subscribers: Dict mapping session_id to set of subscriber queues.
+      _locks: Dict mapping session_id to asyncio.Lock for atomic operations.
 
   Example:
       broadcaster = EventBroadcaster()
 
-      # Subscribe to a session
-      async for event in broadcaster.subscribe("session-1"):
+      # Subscribe with history replay
+      async def fetch_history() -> list[SessionEvent]:
+          return await event_repo.get_by_session("session-1")
+
+      async for event in broadcaster.subscribe("session-1", fetch_history):
           handle_event(event)
 
       # Broadcast an event (in another task)
@@ -37,26 +45,51 @@ class EventBroadcaster:
   """
 
   def __init__(self) -> None:
-    """Initialize the broadcaster with empty subscriber sets."""
+    """Initialize the broadcaster with empty subscriber sets and locks."""
     self._subscribers: dict[str, set[asyncio.Queue[SessionEvent]]] = defaultdict(set)
+    self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
-  async def subscribe(self, session_id: str) -> AsyncIterator[SessionEvent]:
-    """Subscribe to events for a session.
+  async def subscribe(
+    self,
+    session_id: str,
+    history_fetcher: Callable[[], Awaitable[list[SessionEvent]]],
+  ) -> AsyncIterator[SessionEvent]:
+    """Subscribe to events for a session with history replay.
 
-    Creates a new subscriber queue for the session and yields events
-    as they are broadcast. The subscription is automatically cleaned up
-    when the iterator is closed (e.g., via break or exception).
+    Creates a new subscriber queue for the session. History retrieval and
+    queue registration are done atomically (under lock) to prevent race
+    conditions where events could be missed.
+
+    The flow is:
+    1. Create the subscriber queue
+    2. Acquire the session lock
+    3. Inside lock: Fetch history via the callback
+    4. Inside lock: Register the queue to subscribers
+    5. Release lock
+    6. Yield all historical events
+    7. Yield live events from the queue
+    8. On cleanup: Remove the queue from subscribers
 
     Args:
         session_id: The session ID to subscribe to.
+        history_fetcher: Async callback that returns historical events.
 
     Yields:
-        SessionEvent objects as they are broadcast to this session.
+        SessionEvent objects - first historical, then live as they arrive.
     """
     queue: asyncio.Queue[SessionEvent] = asyncio.Queue()
-    self._subscribers[session_id].add(queue)
+
+    # Atomically fetch history and register subscriber
+    async with self._locks[session_id]:
+      history = await history_fetcher()
+      self._subscribers[session_id].add(queue)
 
     try:
+      # Yield historical events first
+      for event in history:
+        yield event
+
+      # Then yield live events
       while True:
         event = await queue.get()
         yield event
@@ -69,18 +102,19 @@ class EventBroadcaster:
   async def broadcast(self, session_id: str, event: SessionEvent) -> None:
     """Broadcast an event to all subscribers for a session.
 
-    Pushes the event to all subscriber queues for the given session.
-    If there are no subscribers, the event is silently dropped.
+    Acquires the session lock to ensure atomic delivery to all current
+    subscribers. This prevents race conditions with concurrent subscribes.
 
     Args:
         session_id: The session ID to broadcast to.
         event: The SessionEvent to broadcast.
     """
-    if session_id not in self._subscribers:
-      return
+    async with self._locks[session_id]:
+      if session_id not in self._subscribers:
+        return
 
-    for queue in self._subscribers[session_id]:
-      await queue.put(event)
+      for queue in self._subscribers[session_id]:
+        await queue.put(event)
 
   def subscriber_count(self, session_id: str) -> int:
     """Get the number of subscribers for a session.

--- a/tests/unit/server/test_broadcaster.py
+++ b/tests/unit/server/test_broadcaster.py
@@ -19,6 +19,11 @@ def _make_event(session_id: str, event_id: str) -> SessionEvent:
   )
 
 
+async def _empty_history() -> list[SessionEvent]:
+  """Return empty history for tests that don't need replay."""
+  return []
+
+
 class TestEventBroadcaster:
   """Test suite for EventBroadcaster."""
 
@@ -42,7 +47,7 @@ class TestEventBroadcaster:
 
     # Start subscription in a task
     async def subscriber() -> None:
-      async for _ in broadcaster.subscribe("session-1"):
+      async for _ in broadcaster.subscribe("session-1", _empty_history):
         break
 
     task = asyncio.create_task(subscriber())
@@ -61,7 +66,7 @@ class TestEventBroadcaster:
     received_events: list[SessionEvent] = []
 
     async def subscriber() -> None:
-      async for event in broadcaster.subscribe("session-1"):
+      async for event in broadcaster.subscribe("session-1", _empty_history):
         received_events.append(event)
         if len(received_events) >= 2:
           break
@@ -88,12 +93,12 @@ class TestEventBroadcaster:
     received_2: list[SessionEvent] = []
 
     async def subscriber_1() -> None:
-      async for event in broadcaster.subscribe("session-1"):
+      async for event in broadcaster.subscribe("session-1", _empty_history):
         received_1.append(event)
         break
 
     async def subscriber_2() -> None:
-      async for event in broadcaster.subscribe("session-1"):
+      async for event in broadcaster.subscribe("session-1", _empty_history):
         received_2.append(event)
         break
 
@@ -122,12 +127,12 @@ class TestEventBroadcaster:
     received_s2: list[SessionEvent] = []
 
     async def subscriber_s1() -> None:
-      async for event in broadcaster.subscribe("session-1"):
+      async for event in broadcaster.subscribe("session-1", _empty_history):
         received_s1.append(event)
         break
 
     async def subscriber_s2() -> None:
-      async for event in broadcaster.subscribe("session-2"):
+      async for event in broadcaster.subscribe("session-2", _empty_history):
         received_s2.append(event)
         break
 
@@ -155,7 +160,7 @@ class TestEventBroadcaster:
     broadcaster = EventBroadcaster()
 
     async def subscriber() -> None:
-      async for _ in broadcaster.subscribe("session-1"):
+      async for _ in broadcaster.subscribe("session-1", _empty_history):
         break
 
     task = asyncio.create_task(subscriber())
@@ -181,3 +186,107 @@ class TestEventBroadcaster:
 
     # Still no subscribers
     assert broadcaster.subscriber_count("session-1") == 0
+
+
+class TestEventBroadcasterHistory:
+  """Tests for history replay functionality."""
+
+  @pytest.mark.asyncio
+  async def test_subscribe_yields_history_first(self) -> None:
+    """Test that subscribe yields historical events before live events."""
+    broadcaster = EventBroadcaster()
+    received_events: list[SessionEvent] = []
+
+    # Create history events
+    history = [
+      _make_event("session-1", "history-1"),
+      _make_event("session-1", "history-2"),
+    ]
+
+    async def fetch_history() -> list[SessionEvent]:
+      return history
+
+    async def subscriber() -> None:
+      async for event in broadcaster.subscribe("session-1", fetch_history):
+        received_events.append(event)
+        if len(received_events) >= 3:
+          break
+
+    task = asyncio.create_task(subscriber())
+    await asyncio.sleep(0.01)
+
+    # Broadcast a live event
+    await broadcaster.broadcast("session-1", _make_event("session-1", "live-1"))
+
+    await task
+
+    assert len(received_events) == 3
+    # History events come first, in order
+    assert received_events[0].event_id == "history-1"
+    assert received_events[1].event_id == "history-2"
+    # Then live event
+    assert received_events[2].event_id == "live-1"
+
+  @pytest.mark.asyncio
+  async def test_history_and_subscription_atomic(self) -> None:
+    """Test that history fetch and registration are atomic.
+
+    This test verifies that events broadcast during the time between
+    history fetch and subscription registration are not lost.
+    """
+    broadcaster = EventBroadcaster()
+    received_events: list[SessionEvent] = []
+    history_fetch_started = asyncio.Event()
+    history_fetch_complete = asyncio.Event()
+
+    # Create a slow history fetcher to simulate the race condition window
+    async def slow_history_fetcher() -> list[SessionEvent]:
+      history_fetch_started.set()
+      await asyncio.sleep(0.05)  # Simulate slow DB query
+      history_fetch_complete.set()
+      return [_make_event("session-1", "history-1")]
+
+    async def subscriber() -> None:
+      async for event in broadcaster.subscribe("session-1", slow_history_fetcher):
+        received_events.append(event)
+        if len(received_events) >= 2:
+          break
+
+    async def broadcaster_task() -> None:
+      # Wait for history fetch to start
+      await history_fetch_started.wait()
+      # Try to broadcast while history is being fetched
+      # This should be blocked by the lock until after registration
+      await broadcaster.broadcast("session-1", _make_event("session-1", "live-1"))
+
+    task = asyncio.create_task(subscriber())
+    broadcast_task = asyncio.create_task(broadcaster_task())
+
+    await task
+    await broadcast_task
+
+    # Both events should be received - history first, then live
+    assert len(received_events) == 2
+    assert received_events[0].event_id == "history-1"
+    assert received_events[1].event_id == "live-1"
+
+  @pytest.mark.asyncio
+  async def test_empty_history_yields_only_live_events(self) -> None:
+    """Test that empty history still works correctly."""
+    broadcaster = EventBroadcaster()
+    received_events: list[SessionEvent] = []
+
+    async def subscriber() -> None:
+      async for event in broadcaster.subscribe("session-1", _empty_history):
+        received_events.append(event)
+        break
+
+    task = asyncio.create_task(subscriber())
+    await asyncio.sleep(0.01)
+
+    await broadcaster.broadcast("session-1", _make_event("session-1", "live-1"))
+
+    await task
+
+    assert len(received_events) == 1
+    assert received_events[0].event_id == "live-1"


### PR DESCRIPTION
- **PR 9: SessionManager shell + create_session()**
- **PR 10: SessionManager.get_session() + Reconnection**
- **PR 11: RequestQueue for sequential request handling**
- **PR 12: EventBroadcaster for session event pub/sub**
- **PR 9: Move persistence protocols to core**
- **Refactor database connection and add centralized test fixture**
- **Fix: Remove backward compatibility alias and cleanup tests**
- **fix: move imports out of TYPE_CHECKING block in test_session_manager.py**
- **refactor: use manager fixture in TestGetSession tests**
- **refactor: simplify RequestQueue with PeekableQueue**
- **refactor: add per-session locking to EventBroadcaster**
