### PR TITLE
ph3f4-f6: SimulatorClient methods (create_session, submit_request, subscribe)

### DIFF
--- a/adk_agent_sim/plugin/client_factory.py
+++ b/adk_agent_sim/plugin/client_factory.py
@@ -1,21 +1,25 @@
-"""SimulatorClient - gRPC client wrapper for server communication.
+"""SimulatorClientFactory - Factory for creating gRPC service stubs.
 
-This module provides the SimulatorClient class that wraps grpclib's Channel
-and provides a high-level interface for communicating with the Simulator Server.
+This module provides the SimulatorClientFactory class that manages gRPC channel
+lifecycle and creates SimulatorServiceStub instances for server communication.
+
+The factory pattern is used because betterproto's generated stub already provides
+a clean API for RPC calls. The factory's role is to manage connection state and
+provide properly configured stubs.
 
 Usage:
-    from adk_agent_sim.plugin.client import SimulatorClient
+    from adk_agent_sim.plugin.client_factory import SimulatorClientFactory
     from adk_agent_sim.plugin.config import PluginConfig
 
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    factory = SimulatorClientFactory(config)
 
-    await client.connect()
     try:
-        # Use the client...
-        pass
+        stub = await factory.get_simulator_stub()
+        # Use the stub for RPC calls...
+        response = await stub.create_session(request)
     finally:
-        await client.close()
+        await factory.close()
 """
 
 from typing import TYPE_CHECKING
@@ -29,27 +33,26 @@ if TYPE_CHECKING:
   from adk_agent_sim.plugin.config import PluginConfig
 
 
-class SimulatorClient:
-  """gRPC client wrapper for communicating with the Simulator Server.
+class SimulatorClientFactory:
+  """Factory for creating SimulatorServiceStub instances.
 
-  This class manages the gRPC channel lifecycle and provides access to the
-  SimulatorService stub for making RPC calls.
+  This class manages the gRPC channel lifecycle and provides stubs for making
+  RPC calls to the Simulator Server. The stub is created on-demand via
+  get_simulator_stub() and uses betterproto's generated API directly.
 
   Attributes:
       config: The plugin configuration containing server connection details.
       channel: The grpclib Channel (set after connect()).
-      stub: The SimulatorServiceStub (set after connect()).
   """
 
   def __init__(self, config: PluginConfig) -> None:
-    """Initialize the SimulatorClient.
+    """Initialize the SimulatorClientFactory.
 
     Args:
         config: Plugin configuration containing server_url and other settings.
     """
     self._config = config
     self._channel: Channel | None = None
-    self._stub: SimulatorServiceStub | None = None
 
   @property
   def config(self) -> PluginConfig:
@@ -62,14 +65,46 @@ class SimulatorClient:
     return self._channel
 
   @property
-  def stub(self) -> SimulatorServiceStub | None:
-    """Get the service stub (None if not connected)."""
-    return self._stub
-
-  @property
   def is_connected(self) -> bool:
     """Check if the client is connected."""
     return self._channel is not None
+
+  async def connect(self) -> None:
+    """Establish a gRPC channel to the server.
+
+    Creates a grpclib Channel and SimulatorServiceStub for making RPC calls.
+
+    Raises:
+        ValueError: If the server URL is invalid.
+        RuntimeError: If already connected.
+    """
+    if self._channel is not None:
+      raise RuntimeError("Client is already connected. Call close() first.")
+
+    host, port = self._parse_server_url()
+    self._channel = Channel(host=host, port=port)
+
+  async def close(self) -> None:
+    """Close the gRPC channel cleanly.
+
+    This should be called when the client is no longer needed to free resources.
+    It is safe to call this method multiple times.
+    """
+    if self._channel is not None:
+      self._channel.close()
+      self._channel = None
+
+  async def get_simulator_stub(self) -> SimulatorServiceStub:
+    """Get the SimulatorServiceStub for making RPC calls.
+
+    Returns:
+        An instance of SimulatorServiceStub.
+    """
+    if not self.is_connected:
+      await self.connect()
+
+    assert self._channel is not None
+    return SimulatorServiceStub(self._channel)
 
   def _parse_server_url(self) -> tuple[str, int]:
     """Parse the server URL into host and port.
@@ -105,30 +140,3 @@ class SimulatorClient:
 
     # Just a hostname, use default port
     return (url or "localhost", 50051)
-
-  async def connect(self) -> None:
-    """Establish a gRPC channel to the server.
-
-    Creates a grpclib Channel and SimulatorServiceStub for making RPC calls.
-
-    Raises:
-        ValueError: If the server URL is invalid.
-        RuntimeError: If already connected.
-    """
-    if self._channel is not None:
-      raise RuntimeError("Client is already connected. Call close() first.")
-
-    host, port = self._parse_server_url()
-    self._channel = Channel(host=host, port=port)
-    self._stub = SimulatorServiceStub(self._channel)
-
-  async def close(self) -> None:
-    """Close the gRPC channel cleanly.
-
-    This should be called when the client is no longer needed to free resources.
-    It is safe to call this method multiple times.
-    """
-    if self._channel is not None:
-      self._channel.close()
-      self._channel = None
-      self._stub = None

--- a/specs/001-server-plugin-core/tasks.md
+++ b/specs/001-server-plugin-core/tasks.md
@@ -393,9 +393,9 @@
 **Goal**: Client method for session creation
 **User Stories**: US1 (Basic Interception)
 
-- [x] T016 [ph3f4] Implement `create_session(description: str | None) -> SimulatorSession` calling server RPC in `adk_agent_sim/plugin/client.py`
-- [x] T017 [ph3f4] Store returned `session_id` for subsequent calls in `adk_agent_sim/plugin/client.py`
-- [x] T018 [ph3f4] Add `create_session()` tests in `tests/unit/plugin/test_client.py`
+- [ ] T016 [ph3f4] Implement `create_session(description: str | None) -> SimulatorSession` calling server RPC in `adk_agent_sim/plugin/client.py`
+- [ ] T017 [ph3f4] Store returned `session_id` for subsequent calls in `adk_agent_sim/plugin/client.py`
+- [ ] T018 [ph3f4] Add `create_session()` tests in `tests/unit/plugin/test_client.py`
 
 ---
 
@@ -406,9 +406,9 @@
 **Goal**: Client method to submit intercepted LLM requests
 **User Stories**: US1 (Basic Interception)
 
-- [x] T019 [ph3f5] Implement `submit_request(turn_id: str, agent_name: str, request: GenerateContentRequest) -> str` in `adk_agent_sim/plugin/client.py`
-- [x] T020 [ph3f5] Return `event_id` from server response in `adk_agent_sim/plugin/client.py`
-- [x] T021 [ph3f5] Add `submit_request()` tests in `tests/unit/plugin/test_client.py`
+- [ ] T019 [ph3f5] Implement `submit_request(turn_id: str, agent_name: str, request: GenerateContentRequest) -> str` in `adk_agent_sim/plugin/client.py`
+- [ ] T020 [ph3f5] Return `event_id` from server response in `adk_agent_sim/plugin/client.py`
+- [ ] T021 [ph3f5] Add `submit_request()` tests in `tests/unit/plugin/test_client.py`
 
 ---
 
@@ -419,9 +419,9 @@
 **Goal**: Client method for event stream subscription
 **User Stories**: US1 (Basic Interception)
 
-- [x] T022 [ph3f6] Implement `subscribe() -> AsyncIterator[SessionEvent]` as async generator in `adk_agent_sim/plugin/client.py`
-- [x] T023 [ph3f6] Yield events from server stream in `adk_agent_sim/plugin/client.py`
-- [x] T024 [ph3f6] Add `subscribe()` tests in `tests/unit/plugin/test_client.py`
+- [ ] T022 [ph3f6] Implement `subscribe() -> AsyncIterator[SessionEvent]` as async generator in `adk_agent_sim/plugin/client.py`
+- [ ] T023 [ph3f6] Yield events from server stream in `adk_agent_sim/plugin/client.py`
+- [ ] T024 [ph3f6] Add `subscribe()` tests in `tests/unit/plugin/test_client.py`
 
 ---
 

--- a/tests/unit/plugin/test_client_factory.py
+++ b/tests/unit/plugin/test_client_factory.py
@@ -1,21 +1,20 @@
-"""Tests for SimulatorClient."""
+"""Tests for SimulatorClientFactory."""
 
 import pytest
 from hamcrest import assert_that, equal_to, instance_of, is_, none
 
-from adk_agent_sim.generated.adksim.v1 import SimulatorServiceStub
-from adk_agent_sim.plugin.client import SimulatorClient
+from adk_agent_sim.plugin.client_factory import SimulatorClientFactory
 from adk_agent_sim.plugin.config import PluginConfig
 
 
-class TestSimulatorClientInit:
-  """Tests for SimulatorClient initialization."""
+class TestSimulatorClientFactoryInit:
+  """Tests for SimulatorClientFactory initialization."""
 
   def test_init_stores_config(self) -> None:
     """__init__ stores the provided config."""
     config = PluginConfig(server_url="http://localhost:9000")
 
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     assert_that(client.config, is_(config))
 
@@ -23,34 +22,26 @@ class TestSimulatorClientInit:
     """__init__ leaves channel as None (not connected)."""
     config = PluginConfig(server_url="http://localhost:9000")
 
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     assert_that(client.channel, is_(none()))
-
-  def test_init_stub_is_none(self) -> None:
-    """__init__ leaves stub as None (not connected)."""
-    config = PluginConfig(server_url="http://localhost:9000")
-
-    client = SimulatorClient(config)
-
-    assert_that(client.stub, is_(none()))
 
   def test_is_connected_false_initially(self) -> None:
     """is_connected returns False before connect() is called."""
     config = PluginConfig(server_url="http://localhost:9000")
 
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     assert_that(client.is_connected, is_(False))
 
 
-class TestSimulatorClientParseServerUrl:
-  """Tests for SimulatorClient URL parsing."""
+class TestSimulatorClientFactoryParseServerUrl:
+  """Tests for SimulatorClientFactory URL parsing."""
 
   def test_parse_http_url_with_port(self) -> None:
     """Parses http://host:port correctly."""
     config = PluginConfig(server_url="http://example.com:8080")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     host, port = client._parse_server_url()
 
@@ -59,7 +50,7 @@ class TestSimulatorClientParseServerUrl:
   def test_parse_http_url_default_port(self) -> None:
     """Parses http://host with default port 50051."""
     config = PluginConfig(server_url="http://example.com")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     host, port = client._parse_server_url()
 
@@ -68,7 +59,7 @@ class TestSimulatorClientParseServerUrl:
   def test_parse_https_url_default_port(self) -> None:
     """Parses https://host with default port 443."""
     config = PluginConfig(server_url="https://example.com")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     host, port = client._parse_server_url()
 
@@ -77,7 +68,7 @@ class TestSimulatorClientParseServerUrl:
   def test_parse_grpc_scheme(self) -> None:
     """Parses grpc://host:port correctly."""
     config = PluginConfig(server_url="grpc://server.local:9999")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     host, port = client._parse_server_url()
 
@@ -86,7 +77,7 @@ class TestSimulatorClientParseServerUrl:
   def test_parse_bare_host_port(self) -> None:
     """Parses host:port format without scheme."""
     config = PluginConfig(server_url="myserver:12345")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     host, port = client._parse_server_url()
 
@@ -95,7 +86,7 @@ class TestSimulatorClientParseServerUrl:
   def test_parse_localhost_default_port(self) -> None:
     """Parses bare localhost with default port."""
     config = PluginConfig(server_url="localhost")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     host, port = client._parse_server_url()
 
@@ -104,20 +95,20 @@ class TestSimulatorClientParseServerUrl:
   def test_parse_invalid_port_raises_value_error(self) -> None:
     """Raises ValueError for invalid port."""
     config = PluginConfig(server_url="host:notaport")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     with pytest.raises(ValueError, match="Invalid port"):
       client._parse_server_url()
 
 
-class TestSimulatorClientConnect:
-  """Tests for SimulatorClient.connect()."""
+class TestSimulatorClientFactoryConnect:
+  """Tests for SimulatorClientFactory.connect()."""
 
   @pytest.mark.asyncio
   async def test_connect_creates_channel(self) -> None:
     """connect() creates a grpclib Channel."""
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     await client.connect()
     try:
@@ -127,22 +118,10 @@ class TestSimulatorClientConnect:
       await client.close()
 
   @pytest.mark.asyncio
-  async def test_connect_creates_stub(self) -> None:
-    """connect() creates a SimulatorServiceStub."""
-    config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
-
-    await client.connect()
-    try:
-      assert_that(client.stub, is_(instance_of(SimulatorServiceStub)))
-    finally:
-      await client.close()
-
-  @pytest.mark.asyncio
   async def test_connect_when_already_connected_raises_runtime_error(self) -> None:
     """connect() raises RuntimeError if already connected."""
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     await client.connect()
     try:
@@ -152,14 +131,14 @@ class TestSimulatorClientConnect:
       await client.close()
 
 
-class TestSimulatorClientClose:
-  """Tests for SimulatorClient.close()."""
+class TestSimulatorClientFactoryClose:
+  """Tests for SimulatorClientFactory.close()."""
 
   @pytest.mark.asyncio
   async def test_close_clears_channel(self) -> None:
     """close() sets channel to None."""
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     await client.connect()
     await client.close()
@@ -167,21 +146,10 @@ class TestSimulatorClientClose:
     assert_that(client.channel, is_(none()))
 
   @pytest.mark.asyncio
-  async def test_close_clears_stub(self) -> None:
-    """close() sets stub to None."""
-    config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
-
-    await client.connect()
-    await client.close()
-
-    assert_that(client.stub, is_(none()))
-
-  @pytest.mark.asyncio
   async def test_close_sets_is_connected_false(self) -> None:
     """close() causes is_connected to return False."""
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     await client.connect()
     await client.close()
@@ -192,7 +160,7 @@ class TestSimulatorClientClose:
   async def test_close_is_idempotent(self) -> None:
     """close() can be called multiple times safely."""
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     await client.connect()
     await client.close()
@@ -204,7 +172,7 @@ class TestSimulatorClientClose:
   async def test_close_without_connect_is_safe(self) -> None:
     """close() is safe to call without prior connect()."""
     config = PluginConfig(server_url="http://localhost:50051")
-    client = SimulatorClient(config)
+    client = SimulatorClientFactory(config)
 
     # Should not raise
     await client.close()


### PR DESCRIPTION
## Summary
Combined PR for SimulatorClient method implementations.

**Note:** The actual code was merged as part of ph3f3 due to merge conflict resolution error. This PR contains:
- Task tracking updates in tasks.md
- Will include fixes based on code review feedback

## Tasks Completed
- T016-T018: create_session() implementation and tests
- T019-T021: submit_request() implementation and tests
- T022-T024: subscribe() implementation and tests

## Code to Review
Please review the SimulatorClient implementation in:
- [adk_agent_sim/plugin/client.py](../blob/main/adk_agent_sim/plugin/client.py)
- [tests/unit/plugin/test_client.py](../blob/main/tests/unit/plugin/test_client.py)

## Testing
- Presubmit passes
- Awaiting review feedback for fixes
