### PR TITLE
fix: add tsconfig.json to adk-sim-protos-ts package

### DIFF
--- a/packages/adk-sim-protos-ts/package.json
+++ b/packages/adk-sim-protos-ts/package.json
@@ -2,8 +2,18 @@
   "name": "@adk-sim/protos",
   "version": "0.1.0",
   "description": "Generated Protocol Buffers for ADK Simulator (TypeScript)",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist"

--- a/packages/adk-sim-protos-ts/tsconfig.json
+++ b/packages/adk-sim-protos-ts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Problem
`npm run build --workspace=packages/adk-sim-protos-ts` was broken - `tsc` printed help instead of compiling because there was no `tsconfig.json`.

## Why CI Didn't Catch It
The frontend imports TypeScript source files directly via workspace resolution (`src/index.ts`), never exercising the build script. The `check_quality.sh` script runs `npm run ng -- build` in the frontend but never runs `npm run build` in the protos-ts package.

## Fix
- Added `tsconfig.json` with proper compiler options
- Updated `package.json`:
  - `main` → `dist/index.js` (built output)
  - `types` → `dist/index.d.ts`
  - Added `exports` field for ESM
  - Added `files` field for npm publishing

## Verification
```bash
npm run build --workspace=packages/adk-sim-protos-ts  # ✅ Now works
./scripts/presubmit.sh  # ✅ Still passes
```
