### PR TITLE
fix: publish workflow path issue and enhance ship.sh

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Bundle frontend into server
         run: |
-          cd frontend && CI=TRUE npm run build
+          cd frontend && CI=TRUE npm run build && cd ..
           rm -rf server/src/adk_sim_server/static/*
           cp -r frontend/dist/frontend/* server/src/adk_sim_server/static/
           echo "Frontend bundled:"

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -2,14 +2,19 @@
 # ============================================================
 # ship.sh - One-command release automation
 # ============================================================
-# Usage: ./scripts/ship.sh {patch|minor|major}
+# Usage: ./scripts/ship.sh [options] {patch|minor|major}
+#
+# Options:
+#   --skip-presubmit  Don't wait for CI checks on the release PR
+#   --yes             Merge PR without prompting for confirmation
 #
 # This script automates the full release process:
 # 1. Creates a release PR with version bump
-# 2. Monitors CI checks until they complete
-# 3. Prompts user to merge the PR
+# 2. Monitors CI checks until they complete (unless --skip-presubmit)
+# 3. Prompts user to merge the PR (unless --yes)
 # 4. Pulls the merged changes
 # 5. Creates and pushes the version tag (triggers publish)
+# 6. Monitors the publish workflow and reports results
 # ============================================================
 
 set -euo pipefail
@@ -27,13 +32,52 @@ success() { echo -e "${GREEN}✓${NC} $1"; }
 warn() { echo -e "${YELLOW}⚠${NC} $1"; }
 error() { echo -e "${RED}✗${NC} $1"; exit 1; }
 
-# Validate arguments
-if [[ $# -ne 1 ]] || [[ ! "$1" =~ ^(patch|minor|major)$ ]]; then
-    echo "Usage: $0 {patch|minor|major}"
+# Default options
+SKIP_PRESUBMIT=false
+AUTO_YES=false
+BUMP_TYPE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-presubmit)
+            SKIP_PRESUBMIT=true
+            shift
+            ;;
+        --yes)
+            AUTO_YES=true
+            shift
+            ;;
+        patch|minor|major)
+            BUMP_TYPE="$1"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [options] {patch|minor|major}"
+            echo ""
+            echo "Options:"
+            echo "  --skip-presubmit  Don't wait for CI checks on the release PR"
+            echo "  --yes             Merge PR without prompting for confirmation"
+            echo ""
+            echo "Examples:"
+            echo "  $0 patch                    # Interactive patch release"
+            echo "  $0 --yes minor              # Auto-merge minor release"
+            echo "  $0 --skip-presubmit patch   # Skip CI wait, prompt for merge"
+            echo "  $0 --skip-presubmit --yes patch  # Fully automated"
+            exit 0
+            ;;
+        *)
+            error "Unknown argument: $1. Use --help for usage."
+            ;;
+    esac
+done
+
+# Validate bump type was provided
+if [[ -z "$BUMP_TYPE" ]]; then
+    echo "Usage: $0 [options] {patch|minor|major}"
+    echo "Use --help for more options."
     exit 1
 fi
-
-BUMP_TYPE="$1"
 
 # Check prerequisites
 command -v gh > /dev/null 2>&1 || error "GitHub CLI (gh) is required"
@@ -49,6 +93,8 @@ fi
 
 echo ""
 echo "🚀 Starting release process (${BUMP_TYPE} bump)"
+[[ "$SKIP_PRESUBMIT" == "true" ]] && echo "   (--skip-presubmit: will not wait for CI)"
+[[ "$AUTO_YES" == "true" ]] && echo "   (--yes: will auto-merge)"
 echo "================================================"
 echo ""
 
@@ -71,13 +117,9 @@ success "Created PR #${PR_NUMBER}: ${PR_URL}"
 echo ""
 
 # ============================================================
-# Step 2: Monitor CI checks
+# Step 2: Monitor CI checks (unless --skip-presubmit)
 # ============================================================
-info "Monitoring CI checks for PR #${PR_NUMBER}..."
-
 check_ci_status() {
-    # Get the status of all checks
-    # Note: gh pr checks uses 'state' field with values: PENDING, SUCCESS, FAILURE, etc.
     gh pr checks "$PR_NUMBER" --json name,state 2>/dev/null || echo "[]"
 }
 
@@ -90,7 +132,6 @@ wait_for_checks() {
         local checks_json
         checks_json=$(check_ci_status)
         
-        # Count check states (state field has: PENDING, SUCCESS, FAILURE, CANCELLED, etc.)
         local total pending passed failed
         total=$(echo "$checks_json" | jq 'length')
         pending=$(echo "$checks_json" | jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
@@ -123,27 +164,40 @@ wait_for_checks() {
     return 1
 }
 
-if ! wait_for_checks; then
-    echo ""
-    read -rp "$(echo -e "${YELLOW}Checks did not all pass. Continue anyway? [y/N]: ${NC}")" continue_anyway
-    if [[ ! "$continue_anyway" =~ ^[Yy]$ ]]; then
-        info "Aborting. You can check the PR at: ${PR_URL}"
-        exit 1
+if [[ "$SKIP_PRESUBMIT" == "true" ]]; then
+    info "Skipping CI check monitoring (--skip-presubmit)"
+else
+    info "Monitoring CI checks for PR #${PR_NUMBER}..."
+    if ! wait_for_checks; then
+        echo ""
+        if [[ "$AUTO_YES" == "true" ]]; then
+            warn "CI checks did not pass, but --yes was specified. Continuing..."
+        else
+            read -rp "$(echo -e "${YELLOW}Checks did not all pass. Continue anyway? [y/N]: ${NC}")" continue_anyway
+            if [[ ! "$continue_anyway" =~ ^[Yy]$ ]]; then
+                info "Aborting. You can check the PR at: ${PR_URL}"
+                exit 1
+            fi
+        fi
     fi
 fi
 
 echo ""
 
 # ============================================================
-# Step 3: Prompt to merge
+# Step 3: Merge PR
 # ============================================================
-read -rp "$(echo -e "${GREEN}Ready to merge PR #${PR_NUMBER}. Proceed? [Y/n]: ${NC}")" do_merge
-if [[ "$do_merge" =~ ^[Nn]$ ]]; then
-    info "Skipping merge. You can merge manually at: ${PR_URL}"
-    exit 0
+if [[ "$AUTO_YES" == "true" ]]; then
+    info "Merging PR #${PR_NUMBER} (--yes)..."
+else
+    read -rp "$(echo -e "${GREEN}Ready to merge PR #${PR_NUMBER}. Proceed? [Y/n]: ${NC}")" do_merge
+    if [[ "$do_merge" =~ ^[Nn]$ ]]; then
+        info "Skipping merge. You can merge manually at: ${PR_URL}"
+        exit 0
+    fi
+    info "Merging PR #${PR_NUMBER}..."
 fi
 
-info "Merging PR #${PR_NUMBER}..."
 gh pr merge "$PR_NUMBER" --squash --delete-branch
 
 success "PR merged!"
@@ -162,7 +216,6 @@ echo ""
 # ============================================================
 # Step 5: Create and push tag
 # ============================================================
-# Extract version from pyproject.toml
 VERSION=$(grep -m1 'version' packages/adk-sim-protos/pyproject.toml | cut -d'"' -f2)
 TAG="v${VERSION}"
 
@@ -174,11 +227,104 @@ success "Tag ${TAG} pushed!"
 echo ""
 
 # ============================================================
-# Done!
+# Step 6: Monitor publish workflow
 # ============================================================
-echo "================================================"
-success "Release ${TAG} initiated!"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+WORKFLOW_URL="https://github.com/${REPO}/actions/workflows/publish.yaml"
+
+info "Monitoring publish workflow for ${TAG}..."
 echo ""
-info "The publish workflow should now be running."
-info "Monitor it at: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/workflows/publish.yaml"
+
+# Wait for the workflow run to appear
+sleep 5
+
+# Get the run ID for this tag
+get_run_id() {
+    gh run list --workflow=publish.yaml --limit=5 --json databaseId,headBranch,status \
+        | jq -r ".[] | select(.headBranch == \"${TAG}\") | .databaseId" \
+        | head -1
+}
+
+RUN_ID=""
+for i in {1..12}; do
+    RUN_ID=$(get_run_id)
+    if [[ -n "$RUN_ID" ]]; then
+        break
+    fi
+    echo -ne "\r⏳ Waiting for publish workflow to start...  "
+    sleep 5
+done
+
+if [[ -z "$RUN_ID" ]]; then
+    warn "Could not find publish workflow run for ${TAG}"
+    info "Check manually at: ${WORKFLOW_URL}"
+    exit 0
+fi
+
 echo ""
+info "Publish workflow started (Run ID: ${RUN_ID})"
+info "View at: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+echo ""
+
+# Monitor the workflow
+monitor_publish() {
+    local max_wait=600  # 10 minutes
+    local elapsed=0
+    local interval=10
+    
+    while [[ $elapsed -lt $max_wait ]]; do
+        local run_json
+        run_json=$(gh run view "$RUN_ID" --json status,conclusion,jobs 2>/dev/null)
+        
+        local status conclusion
+        status=$(echo "$run_json" | jq -r '.status')
+        conclusion=$(echo "$run_json" | jq -r '.conclusion')
+        
+        if [[ "$status" == "completed" ]]; then
+            echo ""
+            if [[ "$conclusion" == "success" ]]; then
+                success "🎉 Publish workflow completed successfully!"
+                echo ""
+                echo "Published packages:"
+                echo "  PyPI: https://pypi.org/project/adk-sim-server/${VERSION}/"
+                echo "  npm:  https://www.npmjs.com/package/@adk-sim/protos/v/${VERSION}"
+                return 0
+            else
+                echo ""
+                warn "Publish workflow failed with conclusion: ${conclusion}"
+                echo ""
+                echo "Failed jobs:"
+                echo "$run_json" | jq -r '.jobs[] | select(.conclusion == "failure") | "  - \(.name)"'
+                echo ""
+                info "View logs at: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+                return 1
+            fi
+        fi
+        
+        # Show job progress
+        local jobs_summary
+        jobs_summary=$(echo "$run_json" | jq -r '[.jobs[] | "\(.name): \(.status)"] | join(", ")')
+        echo -ne "\r⏳ ${jobs_summary}    "
+        
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+    
+    echo ""
+    warn "Timed out waiting for publish workflow (${max_wait}s)"
+    info "Check manually at: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+    return 1
+}
+
+if monitor_publish; then
+    echo ""
+    echo "================================================"
+    success "Release ${TAG} complete! 🚀"
+    echo "================================================"
+else
+    echo ""
+    echo "================================================"
+    warn "Release ${TAG} publishing failed. Check the logs above."
+    echo "================================================"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes the publish workflow failure from v0.1.18 and enhances ship.sh.

## Fixes

- **publish.yaml**: Add `cd ..` after `cd frontend && npm run build`
  - v0.1.18 failed with: `cp: cannot stat 'frontend/dist/frontend/*': No such file or directory`
  - Root cause: After `cd frontend`, the subsequent `cp -r frontend/dist/...` path was wrong (relative to frontend/, not repo root)

## Enhancements (ship.sh)

- Add `--skip-presubmit` flag to skip CI check monitoring
- Add `--yes` flag to auto-merge without prompting
- Add `-h/--help` for usage information
- Add publish workflow monitoring after tag push (shows job progress)
- Report final package URLs on success

## Usage Examples

```bash
# Interactive (current behavior)
./scripts/ship.sh patch

# Fully automated
./scripts/ship.sh --skip-presubmit --yes patch

# Skip CI wait only
./scripts/ship.sh --skip-presubmit patch
```

## Testing

- Changes are straightforward path and flag additions
- v0.1.19 release after this PR will validate the fix