### PR TITLE
S1PR6: SessionStateService (Global Signals)

### DIFF
--- a/frontend/src/app/data-access/session/index.ts
+++ b/frontend/src/app/data-access/session/index.ts
@@ -13,3 +13,7 @@ export { GrpcSessionGateway } from './grpc-session.gateway';
 export { MockSessionGateway } from './mock-session.gateway';
 export type { Session } from './session.gateway';
 export { SessionGateway } from './session.gateway';
+
+// State management
+export type { ConnectionStatus } from './session-state.service';
+export { SessionStateService } from './session-state.service';

--- a/frontend/src/app/data-access/session/session-state.service.spec.ts
+++ b/frontend/src/app/data-access/session/session-state.service.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * @fileoverview Unit tests for SessionStateService.
+ *
+ * Tests verify that the service correctly:
+ * - Initializes with default values
+ * - Exposes readonly signals
+ * - Updates state via mutation methods
+ * - Computes derived state correctly
+ *
+ * @see mddocs/frontend/frontend-tdd.md#sessionstateservice-global
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { SessionStateService, type ConnectionStatus } from './session-state.service';
+
+describe('SessionStateService', () => {
+  let service: SessionStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SessionStateService],
+    });
+    service = TestBed.inject(SessionStateService);
+  });
+
+  describe('initial state', () => {
+    it('should have null sessionId initially', () => {
+      expect(service.sessionId()).toBeNull();
+    });
+
+    it('should have disconnected connectionStatus initially', () => {
+      expect(service.connectionStatus()).toBe('disconnected');
+    });
+
+    it('should have null error initially', () => {
+      expect(service.error()).toBeNull();
+    });
+
+    it('should have isConnected as false initially', () => {
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('should have hasError as false initially', () => {
+      expect(service.hasError()).toBe(false);
+    });
+  });
+
+  describe('setSessionId', () => {
+    it('should update sessionId signal', () => {
+      service.setSessionId('session-123');
+
+      expect(service.sessionId()).toBe('session-123');
+    });
+
+    it('should allow setting sessionId to null', () => {
+      service.setSessionId('session-123');
+      service.setSessionId(null);
+
+      expect(service.sessionId()).toBeNull();
+    });
+
+    it('should allow changing sessionId', () => {
+      service.setSessionId('session-1');
+      service.setSessionId('session-2');
+
+      expect(service.sessionId()).toBe('session-2');
+    });
+  });
+
+  describe('setConnectionStatus', () => {
+    it('should update connectionStatus to connecting', () => {
+      service.setConnectionStatus('connecting');
+
+      expect(service.connectionStatus()).toBe('connecting');
+    });
+
+    it('should update connectionStatus to connected', () => {
+      service.setConnectionStatus('connected');
+
+      expect(service.connectionStatus()).toBe('connected');
+    });
+
+    it('should update connectionStatus to disconnected', () => {
+      service.setConnectionStatus('connected');
+      service.setConnectionStatus('disconnected');
+
+      expect(service.connectionStatus()).toBe('disconnected');
+    });
+
+    it('should update isConnected computed when status changes', () => {
+      expect(service.isConnected()).toBe(false);
+
+      service.setConnectionStatus('connecting');
+      expect(service.isConnected()).toBe(false);
+
+      service.setConnectionStatus('connected');
+      expect(service.isConnected()).toBe(true);
+
+      service.setConnectionStatus('disconnected');
+      expect(service.isConnected()).toBe(false);
+    });
+  });
+
+  describe('setError', () => {
+    it('should update error signal', () => {
+      service.setError('Connection failed');
+
+      expect(service.error()).toBe('Connection failed');
+    });
+
+    it('should allow setting error to null', () => {
+      service.setError('Some error');
+      service.setError(null);
+
+      expect(service.error()).toBeNull();
+    });
+
+    it('should update hasError computed when error changes', () => {
+      expect(service.hasError()).toBe(false);
+
+      service.setError('Error occurred');
+      expect(service.hasError()).toBe(true);
+
+      service.setError(null);
+      expect(service.hasError()).toBe(false);
+    });
+  });
+
+  describe('clearError', () => {
+    it('should clear existing error', () => {
+      service.setError('Some error');
+
+      service.clearError();
+
+      expect(service.error()).toBeNull();
+      expect(service.hasError()).toBe(false);
+    });
+
+    it('should be safe to call when no error exists', () => {
+      service.clearError();
+
+      expect(service.error()).toBeNull();
+      expect(service.hasError()).toBe(false);
+    });
+  });
+
+  describe('state transitions', () => {
+    it('should handle typical connection lifecycle', () => {
+      // Initial state
+      expect(service.connectionStatus()).toBe('disconnected');
+      expect(service.isConnected()).toBe(false);
+
+      // User initiates connection
+      service.setSessionId('session-abc');
+      service.setConnectionStatus('connecting');
+      expect(service.sessionId()).toBe('session-abc');
+      expect(service.connectionStatus()).toBe('connecting');
+      expect(service.isConnected()).toBe(false);
+
+      // Connection established
+      service.setConnectionStatus('connected');
+      expect(service.connectionStatus()).toBe('connected');
+      expect(service.isConnected()).toBe(true);
+
+      // Connection lost
+      service.setConnectionStatus('disconnected');
+      expect(service.connectionStatus()).toBe('disconnected');
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('should handle error during connection', () => {
+      service.setSessionId('session-xyz');
+      service.setConnectionStatus('connecting');
+
+      // Error occurs
+      service.setError('Failed to connect: timeout');
+      service.setConnectionStatus('disconnected');
+
+      expect(service.hasError()).toBe(true);
+      expect(service.error()).toBe('Failed to connect: timeout');
+      expect(service.isConnected()).toBe(false);
+
+      // User retries - clear error
+      service.clearError();
+      service.setConnectionStatus('connecting');
+
+      expect(service.hasError()).toBe(false);
+      expect(service.connectionStatus()).toBe('connecting');
+    });
+
+    it('should handle session change', () => {
+      // Connected to first session
+      service.setSessionId('session-1');
+      service.setConnectionStatus('connected');
+
+      // Switch to new session
+      service.setConnectionStatus('disconnected');
+      service.setSessionId('session-2');
+      service.setConnectionStatus('connecting');
+      service.setConnectionStatus('connected');
+
+      expect(service.sessionId()).toBe('session-2');
+      expect(service.isConnected()).toBe(true);
+    });
+  });
+
+  describe('type safety', () => {
+    it('should only accept valid ConnectionStatus values', () => {
+      const validStatuses: ConnectionStatus[] = ['connected', 'connecting', 'disconnected'];
+
+      for (const status of validStatuses) {
+        service.setConnectionStatus(status);
+        expect(service.connectionStatus()).toBe(status);
+      }
+    });
+  });
+});

--- a/frontend/src/app/data-access/session/session-state.service.ts
+++ b/frontend/src/app/data-access/session/session-state.service.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Global session state management service.
+ *
+ * Provides reactive state for session ID, connection status, and errors
+ * using Angular Signals. This service is a singleton (providedIn: 'root')
+ * and serves as the source of truth for global session state.
+ *
+ * Pattern adapted from prototype: mddocs/frontend/research/prototype-findings.md
+ * @see mddocs/frontend/frontend-tdd.md#sessionstateservice-global
+ */
+
+import { computed, Injectable, signal } from '@angular/core';
+
+/**
+ * Connection status for the gRPC streaming connection.
+ */
+export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
+
+/**
+ * Global session state service using Angular Signals.
+ *
+ * Exposes readonly signals for consumers and mutation methods
+ * for use by the SessionFacade or other orchestrators.
+ *
+ * @example
+ * ```typescript
+ * // In a component
+ * private readonly state = inject(SessionStateService);
+ *
+ * // Read state reactively
+ * readonly sessionId = this.state.sessionId;
+ * readonly isConnected = this.state.isConnected;
+ *
+ * // The facade updates state
+ * // state.setSessionId('session-123');
+ * ```
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionStateService {
+  // ─────────────────────────────────────────────────────────────────────────
+  // Private writable signals
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private readonly _sessionId = signal<string | null>(null);
+  private readonly _connectionStatus = signal<ConnectionStatus>('disconnected');
+  private readonly _error = signal<string | null>(null);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Public readonly signals (encapsulation)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Current active session ID, or null if not in a session. */
+  readonly sessionId = this._sessionId.asReadonly();
+
+  /** Current connection status for the gRPC streaming connection. */
+  readonly connectionStatus = this._connectionStatus.asReadonly();
+
+  /** Error message if an error has occurred, or null otherwise. */
+  readonly error = this._error.asReadonly();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Computed signals (derived state)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Whether the connection is currently established. */
+  readonly isConnected = computed(() => this._connectionStatus() === 'connected');
+
+  /** Whether there is currently an error. */
+  readonly hasError = computed(() => this._error() !== null);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Mutation methods (for use by Facade/orchestrators)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Sets the current session ID.
+   * @param id - The session ID, or null to clear
+   */
+  setSessionId(id: string | null): void {
+    this._sessionId.set(id);
+  }
+
+  /**
+   * Sets the connection status.
+   * @param status - The new connection status
+   */
+  setConnectionStatus(status: ConnectionStatus): void {
+    this._connectionStatus.set(status);
+  }
+
+  /**
+   * Sets an error message.
+   * @param error - The error message, or null to clear
+   */
+  setError(error: string | null): void {
+    this._error.set(error);
+  }
+
+  /**
+   * Clears any current error.
+   */
+  clearError(): void {
+    this._error.set(null);
+  }
+}


### PR DESCRIPTION
## Goal
Create the global session state service with signals for session ID, connection status, and errors.

## Sprint Context
Sprint: 1
Sprint Plan: mddocs/frontend/sprints/sprint1.md
Depends on: S1PR3

## Files Created
- session-state.service.ts: Signal-based state service
- session-state.service.spec.ts: 21 unit tests

## Signals
- sessionId: Current active session ID
- connectionStatus: 'connected' | 'connecting' | 'disconnected'
- error: Error message if any
- isConnected, hasError: Computed signals

## Acceptance Criteria
- [x] sessionId, connectionStatus, error signals exposed as readonly
- [x] isConnected, hasError computed signals work
- [x] Mutation methods update state correctly
- [x] Unit tests cover state transitions
- [x] Presubmit passes

## Background Reading
- [TDD SessionStateService](mddocs/frontend/frontend-tdd.md)
- [Signal-based State Management](mddocs/frontend/research/prototype-findings.md)