### PR TITLE
S1PR7: SessionFacade (Minimal for List)

### DIFF
--- a/frontend/src/app/data-access/session/index.ts
+++ b/frontend/src/app/data-access/session/index.ts
@@ -8,6 +8,9 @@
  * @see mddocs/frontend/frontend-tdd.md#folder-layout
  */
 
+// Facade (primary entry point for components)
+export { SessionFacade } from './session.facade';
+
 // Gateway port and implementations
 export { GrpcSessionGateway } from './grpc-session.gateway';
 export { MockSessionGateway } from './mock-session.gateway';

--- a/frontend/src/app/data-access/session/session.facade.spec.ts
+++ b/frontend/src/app/data-access/session/session.facade.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * @fileoverview Integration tests for SessionFacade.
+ *
+ * Tests verify that the facade correctly orchestrates between
+ * the SessionGateway and SessionStateService. Uses MockSessionGateway
+ * for controlled testing of various scenarios.
+ *
+ * @see mddocs/frontend/frontend-tdd.md#sessionfacade-orchestration
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { create } from '@bufbuild/protobuf';
+
+import { SimulatorSessionSchema } from '@adk-sim/protos';
+
+import { MockSessionGateway } from './mock-session.gateway';
+import { SessionFacade } from './session.facade';
+import { SessionGateway, type Session } from './session.gateway';
+import { SessionStateService } from './session-state.service';
+
+describe('SessionFacade', () => {
+  let facade: SessionFacade;
+  let mockGateway: MockSessionGateway;
+  let stateService: SessionStateService;
+
+  beforeEach(() => {
+    mockGateway = new MockSessionGateway();
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionFacade,
+        SessionStateService,
+        { provide: SessionGateway, useValue: mockGateway },
+      ],
+    });
+
+    facade = TestBed.inject(SessionFacade);
+    stateService = TestBed.inject(SessionStateService);
+  });
+
+  describe('exposed signals', () => {
+    it('should expose sessionId from state service', () => {
+      expect(facade.sessionId()).toBeNull();
+
+      stateService.setSessionId('test-session');
+      expect(facade.sessionId()).toBe('test-session');
+    });
+
+    it('should expose connectionStatus from state service', () => {
+      expect(facade.connectionStatus()).toBe('disconnected');
+
+      stateService.setConnectionStatus('connected');
+      expect(facade.connectionStatus()).toBe('connected');
+    });
+
+    it('should expose error from state service', () => {
+      expect(facade.error()).toBeNull();
+
+      stateService.setError('Test error');
+      expect(facade.error()).toBe('Test error');
+    });
+
+    it('should expose isConnected from state service', () => {
+      expect(facade.isConnected()).toBe(false);
+
+      stateService.setConnectionStatus('connected');
+      expect(facade.isConnected()).toBe(true);
+    });
+
+    it('should expose hasError from state service', () => {
+      expect(facade.hasError()).toBe(false);
+
+      stateService.setError('Test error');
+      expect(facade.hasError()).toBe(true);
+    });
+  });
+
+  describe('listSessions', () => {
+    const mockSessions: Session[] = [
+      create(SimulatorSessionSchema, { id: 'session-1', description: 'First Session' }),
+      create(SimulatorSessionSchema, { id: 'session-2', description: 'Second Session' }),
+    ];
+
+    it('should return sessions from gateway', async () => {
+      mockGateway.setMockSessions(mockSessions);
+
+      const sessions = await facade.listSessions();
+
+      expect(sessions).toEqual(mockSessions);
+    });
+
+    it('should set connectionStatus to connecting before calling gateway', async () => {
+      mockGateway.setMockSessions(mockSessions);
+
+      // Use a delay to check intermediate state
+      mockGateway.setSimulatedDelay(10);
+
+      const promise = facade.listSessions();
+
+      // Should be connecting immediately
+      expect(facade.connectionStatus()).toBe('connecting');
+
+      await promise;
+    });
+
+    it('should set connectionStatus to connected on success', async () => {
+      mockGateway.setMockSessions(mockSessions);
+
+      await facade.listSessions();
+
+      expect(facade.connectionStatus()).toBe('connected');
+    });
+
+    it('should clear error on success', async () => {
+      // Set an initial error
+      stateService.setError('Previous error');
+      mockGateway.setMockSessions(mockSessions);
+
+      await facade.listSessions();
+
+      expect(facade.error()).toBeNull();
+      expect(facade.hasError()).toBe(false);
+    });
+
+    it('should set connectionStatus to disconnected on error', async () => {
+      mockGateway.setErrorToThrow(new Error('Connection failed'));
+
+      await expect(facade.listSessions()).rejects.toThrow('Connection failed');
+
+      expect(facade.connectionStatus()).toBe('disconnected');
+    });
+
+    it('should set error message on error', async () => {
+      mockGateway.setErrorToThrow(new Error('Connection failed'));
+
+      await expect(facade.listSessions()).rejects.toThrow();
+
+      expect(facade.error()).toBe('Connection failed');
+      expect(facade.hasError()).toBe(true);
+    });
+
+    it('should re-throw the original error', async () => {
+      const testError = new Error('Test error');
+      mockGateway.setErrorToThrow(testError);
+
+      await expect(facade.listSessions()).rejects.toThrow(testError);
+    });
+
+    it('should handle non-Error objects thrown', async () => {
+      // Some gRPC errors might not be proper Error instances
+      // Create a plain object to simulate this
+      const notAnError = { someProperty: 'Not a real error' };
+      mockGateway.setErrorToThrow(notAnError as unknown as Error);
+
+      await expect(facade.listSessions()).rejects.toBeDefined();
+
+      // Should use fallback message for non-Error objects
+      expect(facade.error()).toBe('An unknown error occurred');
+    });
+
+    it('should return empty array when no sessions exist', async () => {
+      mockGateway.setMockSessions([]);
+
+      const sessions = await facade.listSessions();
+
+      expect(sessions).toEqual([]);
+      expect(facade.connectionStatus()).toBe('connected');
+    });
+
+    describe('state transitions', () => {
+      it('should transition disconnected -> connecting -> connected on success', async () => {
+        const statusTransitions: string[] = [];
+
+        mockGateway.setMockSessions(mockSessions);
+        mockGateway.setSimulatedDelay(10);
+
+        // Record initial state
+        statusTransitions.push(facade.connectionStatus());
+
+        const promise = facade.listSessions();
+
+        // Record connecting state
+        statusTransitions.push(facade.connectionStatus());
+
+        await promise;
+
+        // Record final state
+        statusTransitions.push(facade.connectionStatus());
+
+        expect(statusTransitions).toEqual(['disconnected', 'connecting', 'connected']);
+      });
+
+      it('should transition disconnected -> connecting -> disconnected on error', async () => {
+        const statusTransitions: string[] = [];
+
+        mockGateway.setErrorToThrow(new Error('Failed'));
+        mockGateway.setSimulatedDelay(10);
+
+        // Record initial state
+        statusTransitions.push(facade.connectionStatus());
+
+        const promise = facade.listSessions();
+
+        // Record connecting state
+        statusTransitions.push(facade.connectionStatus());
+
+        try {
+          await promise;
+        } catch {
+          // Expected
+        }
+
+        // Record final state
+        statusTransitions.push(facade.connectionStatus());
+
+        expect(statusTransitions).toEqual(['disconnected', 'connecting', 'disconnected']);
+      });
+    });
+  });
+});

--- a/frontend/src/app/data-access/session/session.facade.ts
+++ b/frontend/src/app/data-access/session/session.facade.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Session facade for orchestrating gateway and state.
+ *
+ * The facade provides a single point of entry for session operations,
+ * coordinating between the SessionGateway (backend communication) and
+ * SessionStateService (reactive state). Components should use this facade
+ * rather than directly accessing the gateway or state service.
+ *
+ * Per the TDD Facade Pattern recommendation:
+ * @see mddocs/frontend/frontend-tdd.md#sessionfacade-orchestration
+ * @see mddocs/frontend/research/angular-architecture-analysis.md#critical-improvement-the-facade-pattern
+ */
+
+import { inject, Injectable } from '@angular/core';
+
+import type { Session } from './session.gateway';
+import { SessionGateway } from './session.gateway';
+import { SessionStateService } from './session-state.service';
+
+/**
+ * Session facade for orchestrating gateway and state operations.
+ *
+ * This facade provides:
+ * - Readonly access to session state signals
+ * - Coordinated operations that update state based on gateway results
+ * - Error handling with state propagation
+ *
+ * @example
+ * ```typescript
+ * // In a component
+ * private readonly facade = inject(SessionFacade);
+ *
+ * // Read state reactively
+ * readonly connectionStatus = this.facade.connectionStatus;
+ * readonly error = this.facade.error;
+ *
+ * async loadSessions() {
+ *   try {
+ *     const sessions = await this.facade.listSessions();
+ *     // Handle sessions...
+ *   } catch (error) {
+ *     // Error already set in state
+ *   }
+ * }
+ * ```
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionFacade {
+  private readonly gateway = inject(SessionGateway);
+  private readonly stateService = inject(SessionStateService);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Expose state signals (readonly, for components to consume)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Current active session ID, or null if not in a session. */
+  readonly sessionId = this.stateService.sessionId;
+
+  /** Current connection status for the backend connection. */
+  readonly connectionStatus = this.stateService.connectionStatus;
+
+  /** Error message if an error has occurred, or null otherwise. */
+  readonly error = this.stateService.error;
+
+  /** Whether the connection is currently established. */
+  readonly isConnected = this.stateService.isConnected;
+
+  /** Whether there is currently an error. */
+  readonly hasError = this.stateService.hasError;
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Operations (coordinate gateway + state)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Lists all available sessions.
+   *
+   * Updates connection status and error state based on the result.
+   * On success: sets status to 'connected' and clears any error.
+   * On failure: sets status to 'disconnected' and sets error message.
+   *
+   * @returns Promise resolving to array of sessions
+   * @throws Re-throws the original error after updating state
+   */
+  async listSessions(): Promise<Session[]> {
+    try {
+      this.stateService.setConnectionStatus('connecting');
+
+      const sessions = await this.gateway.listSessions();
+
+      this.stateService.setConnectionStatus('connected');
+      this.stateService.clearError();
+
+      return sessions;
+    } catch (error) {
+      this.stateService.setConnectionStatus('disconnected');
+      this.stateService.setError(
+        error instanceof Error ? error.message : 'An unknown error occurred',
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Goal
Create a minimal facade that orchestrates gateway + state for listing sessions.

## Sprint Context
Sprint: 1
Sprint Plan: mddocs/frontend/sprints/sprint1.md
Depends on: S1PR4, S1PR5, S1PR6

## Files Created
- session.facade.ts: Facade orchestrating gateway + state
- session.facade.spec.ts: 16 integration tests

## Features
- listSessions() with state transitions
- Exposes state signals from SessionStateService
- Error handling updates state before re-throwing

## Acceptance Criteria
- [x] SessionFacade.listSessions() method works
- [x] Exposes state signals from SessionStateService
- [x] Tests use MockSessionGateway
- [x] Presubmit passes

## Background Reading
- [TDD SessionFacade](mddocs/frontend/frontend-tdd.md)
- [Facade Pattern](mddocs/frontend/research/angular-architecture-analysis.md)