### PR TITLE
fix(ci): Add timeout and error detection to frontend tests

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -54,23 +54,45 @@ echo ""
 echo "🧪 Running Frontend Tests..."
 cd frontend
 
-# Capture stderr to detect warnings - Angular/Vitest warnings should fail presubmit
-TEST_STDERR_FILE=$(mktemp)
-if ! CI=true npm run ng -- test --watch=false 2> >(tee "$TEST_STDERR_FILE" >&2); then
-  echo "❌ Frontend tests failed!"
-  rm -f "$TEST_STDERR_FILE"
+# Capture both stdout and stderr to detect test failures and warnings
+TEST_OUTPUT_FILE=$(mktemp)
+TEST_EXIT_CODE=0
+
+# Run tests with a 5-minute timeout to prevent hanging
+if ! timeout 300 bash -c 'CI=true npm run ng -- test --watch=false 2>&1' | tee "$TEST_OUTPUT_FILE"; then
+  TEST_EXIT_CODE=$?
+fi
+
+# Check for vitest unhandled errors (indicates missing dependencies or runtime issues)
+if grep -q "Unhandled Errors\|Cannot find package\|ERR_MODULE_NOT_FOUND" "$TEST_OUTPUT_FILE" 2>/dev/null; then
+  echo ""
+  echo "❌ Frontend tests failed with unhandled errors:"
+  grep -A 5 "Unhandled Error\|Cannot find package\|ERR_MODULE_NOT_FOUND" "$TEST_OUTPUT_FILE"
+  rm -f "$TEST_OUTPUT_FILE"
   exit 1
 fi
 
-# Check for Angular warnings in stderr (excluding expected output)
-if grep -q "It looks like you're using" "$TEST_STDERR_FILE" 2>/dev/null; then
+# Check if tests actually ran and passed
+if ! grep -q "Tests.*[0-9]* passed" "$TEST_OUTPUT_FILE" 2>/dev/null; then
+  # If no tests passed and we had a non-zero exit, fail
+  if [ $TEST_EXIT_CODE -ne 0 ]; then
+    echo ""
+    echo "❌ Frontend tests failed (exit code: $TEST_EXIT_CODE)"
+    rm -f "$TEST_OUTPUT_FILE"
+    exit 1
+  fi
+fi
+
+# Check for Angular warnings in output
+if grep -q "It looks like you're using" "$TEST_OUTPUT_FILE" 2>/dev/null; then
   echo ""
   echo "❌ Frontend tests produced Angular warnings - please fix them:"
-  grep -A 10 "It looks like you're using" "$TEST_STDERR_FILE"
-  rm -f "$TEST_STDERR_FILE"
+  grep -A 10 "It looks like you're using" "$TEST_OUTPUT_FILE"
+  rm -f "$TEST_OUTPUT_FILE"
   exit 1
 fi
-rm -f "$TEST_STDERR_FILE"
+
+rm -f "$TEST_OUTPUT_FILE"
 
 echo ""
 echo "✅ All presubmit checks passed!"


### PR DESCRIPTION
## Problem

Frontend unit tests were silently hanging/failing in CI due to jsdom module resolution issues. The previous presubmit script didn't detect this because:

1. No timeout - tests could hang indefinitely
2. No detection of vitest 'Unhandled Errors' 
3. No verification that tests actually ran

## Solution

- Add 5-minute timeout to prevent hanging tests  
- Detect vitest 'Unhandled Errors' and 'Cannot find package' issues
- Verify tests actually ran by checking for passed tests in output

## Expected Result

This PR should **fail CI** to demonstrate it now properly detects the jsdom issue. A follow-up commit will fix the underlying problem.