### PR TITLE
S1PR14: npm Publishing CI for @adk-sim/converters

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,8 +45,10 @@ jobs:
           uv build --package adk-sim-server --out-dir dist/
           uv build --package adk-agent-sim --out-dir dist/
 
-      - name: Build TypeScript package
-        run: npm run build --workspace=packages/adk-sim-protos-ts
+      - name: Build TypeScript packages
+        run: |
+          npm run build --workspace=packages/adk-sim-protos-ts
+          npm run build --workspace=packages/adk-converters-ts
 
       - name: Verify Python installation (local wheels)
         run: |
@@ -140,15 +142,21 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install and build
-        working-directory: packages/adk-sim-protos-ts
         run: |
           npm ci
-          npm run build
+          npm run build --workspace=packages/adk-sim-protos-ts
+          npm run build --workspace=packages/adk-converters-ts
 
-      - name: Publish to npm
+      - name: Publish @adk-sim/protos to npm
         working-directory: packages/adk-sim-protos-ts
         run: |
           # Unset NODE_AUTH_TOKEN to force npm to use OIDC instead of token auth
           # See: https://github.com/npm/cli/issues/1440
+          unset NODE_AUTH_TOKEN
+          npm publish --provenance --access public
+
+      - name: Publish @adk-sim/converters to npm
+        working-directory: packages/adk-converters-ts
+        run: |
           unset NODE_AUTH_TOKEN
           npm publish --provenance --access public

--- a/packages/adk-converters-ts/package.json
+++ b/packages/adk-converters-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adk-sim/converters",
-  "version": "0.1.0",
+  "version": "0.1.19",
   "description": "Conversion utilities between ADK types and Simulator proto types",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,7 +26,12 @@
     "typescript": "~5.8.0",
     "vitest": "^3.0.0"
   },
-  "keywords": ["adk", "simulator", "converters", "protobuf"],
+  "keywords": [
+    "adk",
+    "simulator",
+    "converters",
+    "protobuf"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Goal
Update publish.yaml to build and publish the @adk-sim/converters package.

## Sprint Context
Sprint: 1
Sprint Plan: mddocs/frontend/sprints/sprint1.md

## Changes
- Updated `verify-build` job to build converters package alongside protos
- Updated `publish-npm` job to publish both @adk-sim/protos and @adk-sim/converters
- Added converters package to `sync_versions.py` for version synchronization

## Acceptance Criteria
- [x] `verify-build` job builds converters package
- [x] `publish-npm` job publishes converters (trusted publisher configured)
- [x] `sync_versions.py` includes converters package path
- [x] Workflow syntax valid