### PR TITLE
S2PR7: Response construction helpers

### DIFF
--- a/mddocs/frontend/sprints/sprint2.md
+++ b/mddocs/frontend/sprints/sprint2.md
@@ -343,13 +343,13 @@ The `GenerateContentConfig` interface contains `systemInstruction`, `temperature
 - [FR Response Construction](../frontend-spec.md#fr-response-construction) - FR-017, FR-018, FR-019
 
 **Acceptance Criteria**:
-- [ ] `createTextResponse(text: string)` creates proto for text-only response
-- [ ] `createToolInvocationResponse(toolName: string, args: unknown)` creates proto for function call
-- [ ] `createFunctionResultResponse(toolName: string, result: unknown)` creates proto for function response
-- [ ] `createStructuredResponse(data: unknown)` creates proto for JSON schema response
-- [ ] All helpers return valid `GenerateContentResponse` protos
-- [ ] Tests verify proto structure for each helper
-- [ ] Presubmit passes
+- [x] `createTextResponse(text: string)` creates proto for text-only response
+- [x] `createToolInvocationResponse(toolName: string, args: unknown)` creates proto for function call
+- [x] `createFunctionResultResponse(toolName: string, result: unknown)` creates proto for function response
+- [x] `createStructuredResponse(data: unknown)` creates proto for JSON schema response
+- [x] All helpers return valid `GenerateContentResponse` protos
+- [x] Tests verify proto structure for each helper
+- [x] Presubmit passes
 
 ---
 

--- a/packages/adk-converters-ts/src/index.ts
+++ b/packages/adk-converters-ts/src/index.ts
@@ -50,6 +50,14 @@ export {
   type LlmResponseConversionResult,
 } from './response-converter.js';
 
+// Response construction helpers
+export {
+  createTextResponse,
+  createToolInvocationResponse,
+  createFunctionResultResponse,
+  createStructuredResponse,
+} from './response-helpers.js';
+
 // Re-export @google/genai types for convenience
 export type {
   Content,

--- a/packages/adk-converters-ts/src/response-helpers.spec.ts
+++ b/packages/adk-converters-ts/src/response-helpers.spec.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createTextResponse,
+  createToolInvocationResponse,
+  createFunctionResultResponse,
+  createStructuredResponse,
+} from './response-helpers.js';
+import { Candidate_FinishReason } from '@adk-sim/protos';
+
+describe('response-helpers', () => {
+  describe('createTextResponse', () => {
+    it('creates a valid GenerateContentResponse for text', () => {
+      const response = createTextResponse('Hello, world!');
+
+      expect(response.$typeName).toBe(
+        'google.ai.generativelanguage.v1beta.GenerateContentResponse',
+      );
+      expect(response.candidates).toHaveLength(1);
+
+      const candidate = response.candidates[0];
+      expect(candidate.finishReason).toBe(Candidate_FinishReason.STOP);
+      expect(candidate.content).toBeDefined();
+      expect(candidate.content?.role).toBe('model');
+      expect(candidate.content?.parts).toHaveLength(1);
+
+      const part = candidate.content?.parts[0];
+      expect(part?.data.case).toBe('text');
+      expect(part?.data.value).toBe('Hello, world!');
+    });
+
+    it('handles empty text', () => {
+      const response = createTextResponse('');
+
+      const part = response.candidates[0].content?.parts[0];
+      expect(part?.data.case).toBe('text');
+      expect(part?.data.value).toBe('');
+    });
+
+    it('handles text with special characters', () => {
+      const specialText = 'Line1\nLine2\tTabbed "quoted" and \'apostrophe\'';
+      const response = createTextResponse(specialText);
+
+      const part = response.candidates[0].content?.parts[0];
+      expect(part?.data.value).toBe(specialText);
+    });
+  });
+
+  describe('createToolInvocationResponse', () => {
+    it('creates a valid GenerateContentResponse for function call', () => {
+      const response = createToolInvocationResponse('get_weather', { location: 'Paris' });
+
+      expect(response.$typeName).toBe(
+        'google.ai.generativelanguage.v1beta.GenerateContentResponse',
+      );
+      expect(response.candidates).toHaveLength(1);
+
+      const candidate = response.candidates[0];
+      expect(candidate.finishReason).toBe(Candidate_FinishReason.STOP);
+      expect(candidate.content?.role).toBe('model');
+
+      const part = candidate.content?.parts[0];
+      expect(part?.data.case).toBe('functionCall');
+
+      if (part?.data.case === 'functionCall') {
+        expect(part.data.value.name).toBe('get_weather');
+        expect(part.data.value.args).toEqual({ location: 'Paris' });
+      } else {
+        throw new Error('Expected functionCall part');
+      }
+    });
+
+    it('handles complex arguments', () => {
+      const complexArgs = {
+        name: 'test',
+        count: 42,
+        enabled: true,
+        nested: { foo: 'bar', arr: [1, 2, 3] },
+      };
+      const response = createToolInvocationResponse('complex_tool', complexArgs);
+
+      const part = response.candidates[0].content?.parts[0];
+      if (part?.data.case === 'functionCall') {
+        expect(part.data.value.args).toEqual(complexArgs);
+      } else {
+        throw new Error('Expected functionCall part');
+      }
+    });
+
+    it('handles empty arguments', () => {
+      const response = createToolInvocationResponse('no_args_tool', {});
+
+      const part = response.candidates[0].content?.parts[0];
+      if (part?.data.case === 'functionCall') {
+        expect(part.data.value.name).toBe('no_args_tool');
+        expect(part.data.value.args).toEqual({});
+      } else {
+        throw new Error('Expected functionCall part');
+      }
+    });
+  });
+
+  describe('createFunctionResultResponse', () => {
+    it('creates a valid GenerateContentResponse for function response', () => {
+      const result = { temperature: 22, unit: 'celsius', conditions: 'sunny' };
+      const response = createFunctionResultResponse('get_weather', result);
+
+      expect(response.$typeName).toBe(
+        'google.ai.generativelanguage.v1beta.GenerateContentResponse',
+      );
+      expect(response.candidates).toHaveLength(1);
+
+      const candidate = response.candidates[0];
+      expect(candidate.finishReason).toBe(Candidate_FinishReason.STOP);
+      expect(candidate.content?.role).toBe('model');
+
+      const part = candidate.content?.parts[0];
+      expect(part?.data.case).toBe('functionResponse');
+
+      if (part?.data.case === 'functionResponse') {
+        expect(part.data.value.name).toBe('get_weather');
+        expect(part.data.value.response).toEqual(result);
+      } else {
+        throw new Error('Expected functionResponse part');
+      }
+    });
+
+    it('handles string result', () => {
+      const response = createFunctionResultResponse('string_tool', 'success');
+
+      const part = response.candidates[0].content?.parts[0];
+      if (part?.data.case === 'functionResponse') {
+        expect(part.data.value.response).toBe('success');
+      } else {
+        throw new Error('Expected functionResponse part');
+      }
+    });
+
+    it('handles null result', () => {
+      const response = createFunctionResultResponse('void_tool', null);
+
+      const part = response.candidates[0].content?.parts[0];
+      if (part?.data.case === 'functionResponse') {
+        expect(part.data.value.response).toBeNull();
+      } else {
+        throw new Error('Expected functionResponse part');
+      }
+    });
+
+    it('handles array result', () => {
+      const arrayResult = [1, 2, 3, { nested: true }];
+      const response = createFunctionResultResponse('array_tool', arrayResult);
+
+      const part = response.candidates[0].content?.parts[0];
+      if (part?.data.case === 'functionResponse') {
+        expect(part.data.value.response).toEqual(arrayResult);
+      } else {
+        throw new Error('Expected functionResponse part');
+      }
+    });
+  });
+
+  describe('createStructuredResponse', () => {
+    it('creates a valid GenerateContentResponse for structured data', () => {
+      const data = { name: 'John', age: 30, active: true };
+      const response = createStructuredResponse(data);
+
+      expect(response.$typeName).toBe(
+        'google.ai.generativelanguage.v1beta.GenerateContentResponse',
+      );
+      expect(response.candidates).toHaveLength(1);
+
+      const candidate = response.candidates[0];
+      expect(candidate.finishReason).toBe(Candidate_FinishReason.STOP);
+      expect(candidate.content?.role).toBe('model');
+
+      const part = candidate.content?.parts[0];
+      expect(part?.data.case).toBe('text');
+      expect(part?.data.value).toBe(JSON.stringify(data));
+    });
+
+    it('handles arrays', () => {
+      const data = [{ id: 1 }, { id: 2 }];
+      const response = createStructuredResponse(data);
+
+      const part = response.candidates[0].content?.parts[0];
+      expect(part?.data.value).toBe(JSON.stringify(data));
+    });
+
+    it('handles nested structures', () => {
+      const data = {
+        user: {
+          profile: {
+            settings: {
+              theme: 'dark',
+            },
+          },
+        },
+      };
+      const response = createStructuredResponse(data);
+
+      const part = response.candidates[0].content?.parts[0];
+      expect(part?.data.value).toBe(JSON.stringify(data));
+    });
+
+    it('handles primitive values', () => {
+      const numberResponse = createStructuredResponse(42);
+      expect(numberResponse.candidates[0].content?.parts[0].data.value).toBe('42');
+
+      const stringResponse = createStructuredResponse('hello');
+      expect(stringResponse.candidates[0].content?.parts[0].data.value).toBe('"hello"');
+
+      const boolResponse = createStructuredResponse(true);
+      expect(boolResponse.candidates[0].content?.parts[0].data.value).toBe('true');
+    });
+
+    it('handles null', () => {
+      const response = createStructuredResponse(null);
+
+      const part = response.candidates[0].content?.parts[0];
+      expect(part?.data.value).toBe('null');
+    });
+  });
+
+  describe('response structure validation', () => {
+    it('all helpers return responses with required proto fields', () => {
+      const helpers = [
+        () => createTextResponse('test'),
+        () => createToolInvocationResponse('tool', {}),
+        () => createFunctionResultResponse('tool', {}),
+        () => createStructuredResponse({}),
+      ];
+
+      helpers.forEach((createResponse) => {
+        const response = createResponse();
+
+        // Verify $typeName
+        expect(response.$typeName).toBe(
+          'google.ai.generativelanguage.v1beta.GenerateContentResponse',
+        );
+
+        // Verify candidate structure
+        expect(response.candidates).toHaveLength(1);
+        const candidate = response.candidates[0];
+        expect(candidate.$typeName).toBe('google.ai.generativelanguage.v1beta.Candidate');
+        expect(candidate.finishReason).toBeDefined();
+        expect(candidate.safetyRatings).toEqual([]);
+
+        // Verify content structure
+        expect(candidate.content).toBeDefined();
+        expect(candidate.content?.$typeName).toBe('google.ai.generativelanguage.v1beta.Content');
+        expect(candidate.content?.role).toBe('model');
+        expect(candidate.content?.parts).toHaveLength(1);
+
+        // Verify part structure
+        const part = candidate.content?.parts[0];
+        expect(part?.$typeName).toBe('google.ai.generativelanguage.v1beta.Part');
+        expect(part?.data.case).toBeDefined();
+        expect(part?.thought).toBe(false);
+
+        // Verify usage metadata
+        expect(response.usageMetadata).toBeDefined();
+        expect(response.usageMetadata?.$typeName).toBe(
+          'google.ai.generativelanguage.v1beta.GenerateContentResponse.UsageMetadata',
+        );
+      });
+    });
+  });
+});

--- a/packages/adk-converters-ts/src/response-helpers.ts
+++ b/packages/adk-converters-ts/src/response-helpers.ts
@@ -1,0 +1,176 @@
+/**
+ * Response Construction Helpers
+ *
+ * Convenience factory functions for creating common response types
+ * that the frontend needs to submit.
+ */
+
+import type {
+  GenerateContentResponse,
+  Candidate,
+  Content as ProtoContent,
+  Part as ProtoPart,
+  FunctionCall as ProtoFunctionCall,
+  FunctionResponse as ProtoFunctionResponse,
+  GenerateContentResponse_UsageMetadata,
+} from '@adk-sim/protos';
+import { Candidate_FinishReason } from '@adk-sim/protos';
+
+/**
+ * Creates a GenerateContentResponse proto for a text-only response.
+ * Used for final answers from the model.
+ *
+ * @param text - The text content of the response
+ * @returns A GenerateContentResponse proto with the text wrapped in candidates[0].content
+ */
+export function createTextResponse(text: string): GenerateContentResponse {
+  const textPart: ProtoPart = {
+    $typeName: 'google.ai.generativelanguage.v1beta.Part',
+    data: { case: 'text', value: text },
+    thought: false,
+    thoughtSignature: new Uint8Array(),
+    metadata: { case: undefined, value: undefined },
+  } as ProtoPart;
+
+  return buildResponse([textPart], Candidate_FinishReason.STOP);
+}
+
+/**
+ * Creates a GenerateContentResponse proto for a function call / tool invocation.
+ * Used when the model wants to invoke a tool.
+ *
+ * @param toolName - The name of the tool/function to call
+ * @param args - The arguments to pass to the function
+ * @returns A GenerateContentResponse proto with a function call part
+ */
+export function createToolInvocationResponse(
+  toolName: string,
+  args: Record<string, unknown>,
+): GenerateContentResponse {
+  const functionCall: ProtoFunctionCall = {
+    $typeName: 'google.ai.generativelanguage.v1beta.FunctionCall',
+    id: '',
+    name: toolName,
+    args: args,
+  } as ProtoFunctionCall;
+
+  const functionCallPart: ProtoPart = {
+    $typeName: 'google.ai.generativelanguage.v1beta.Part',
+    data: { case: 'functionCall', value: functionCall },
+    thought: false,
+    thoughtSignature: new Uint8Array(),
+    metadata: { case: undefined, value: undefined },
+  } as ProtoPart;
+
+  // Function calls typically don't have STOP as finish reason
+  // Some implementations use UNSPECIFIED or a specific reason
+  // We'll use STOP as it's a valid completed response
+  return buildResponse([functionCallPart], Candidate_FinishReason.STOP);
+}
+
+/**
+ * Creates a GenerateContentResponse proto for a function result.
+ * Used to provide the return value from a simulated tool execution.
+ *
+ * @param toolName - The name of the tool/function that was called
+ * @param result - The result from the function execution
+ * @returns A GenerateContentResponse proto with a function response part
+ */
+export function createFunctionResultResponse(
+  toolName: string,
+  result: unknown,
+): GenerateContentResponse {
+  const functionResponse: ProtoFunctionResponse = {
+    $typeName: 'google.ai.generativelanguage.v1beta.FunctionResponse',
+    id: '',
+    name: toolName,
+    response: result as Record<string, unknown> | undefined,
+    parts: [],
+    willContinue: false,
+  } as ProtoFunctionResponse;
+
+  const functionResponsePart: ProtoPart = {
+    $typeName: 'google.ai.generativelanguage.v1beta.Part',
+    data: { case: 'functionResponse', value: functionResponse },
+    thought: false,
+    thoughtSignature: new Uint8Array(),
+    metadata: { case: undefined, value: undefined },
+  } as ProtoPart;
+
+  return buildResponse([functionResponsePart], Candidate_FinishReason.STOP);
+}
+
+/**
+ * Creates a GenerateContentResponse proto for a structured JSON response.
+ * Used for JSON schema responses where the content is structured data.
+ *
+ * @param data - The structured data to include in the response
+ * @returns A GenerateContentResponse proto with the JSON stringified in a text part
+ */
+export function createStructuredResponse(data: unknown): GenerateContentResponse {
+  // Structured responses are typically returned as JSON text
+  const jsonText = JSON.stringify(data);
+
+  const textPart: ProtoPart = {
+    $typeName: 'google.ai.generativelanguage.v1beta.Part',
+    data: { case: 'text', value: jsonText },
+    thought: false,
+    thoughtSignature: new Uint8Array(),
+    metadata: { case: undefined, value: undefined },
+  } as ProtoPart;
+
+  return buildResponse([textPart], Candidate_FinishReason.STOP);
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/**
+ * Builds a GenerateContentResponse with the given parts and finish reason.
+ */
+function buildResponse(
+  parts: ProtoPart[],
+  finishReason: Candidate_FinishReason,
+): GenerateContentResponse {
+  const content: ProtoContent = {
+    $typeName: 'google.ai.generativelanguage.v1beta.Content',
+    role: 'model',
+    parts,
+  } as ProtoContent;
+
+  const candidate: Candidate = {
+    $typeName: 'google.ai.generativelanguage.v1beta.Candidate',
+    content,
+    finishReason,
+    safetyRatings: [],
+    citationMetadata: undefined,
+    tokenCount: 0,
+    groundingAttributions: [],
+    index: 0,
+    avgLogprobs: 0,
+  };
+
+  const usageMetadata: GenerateContentResponse_UsageMetadata = {
+    $typeName: 'google.ai.generativelanguage.v1beta.GenerateContentResponse.UsageMetadata',
+    promptTokenCount: 0,
+    candidatesTokenCount: 0,
+    totalTokenCount: 0,
+    cachedContentTokenCount: 0,
+    toolUsePromptTokenCount: 0,
+    thoughtsTokenCount: 0,
+    promptTokensDetails: [],
+    cacheTokensDetails: [],
+    candidatesTokensDetails: [],
+    toolUsePromptTokensDetails: [],
+  };
+
+  return {
+    $typeName: 'google.ai.generativelanguage.v1beta.GenerateContentResponse',
+    candidates: [candidate],
+    promptFeedback: undefined,
+    usageMetadata,
+    modelVersion: '',
+    responseId: '',
+  };
+}


### PR DESCRIPTION
## Goal
Add convenience factory functions for creating common response types that the frontend needs to submit.

## Sprint Context
Sprint: 2
Sprint Plan: mddocs/frontend/sprints/sprint2.md

## Acceptance Criteria
- [x] `createTextResponse(text)` creates proto for text-only response
- [x] `createToolInvocationResponse(toolName, args)` creates proto for function call
- [x] `createFunctionResultResponse(toolName, result)` creates proto for function response
- [x] `createStructuredResponse(data)` creates proto for JSON schema response
- [x] All helpers return valid GenerateContentResponse protos
- [x] Tests verify proto structure for each helper (16 tests)
- [x] Presubmit passes

## Background Reading
- [TDD SessionFacade methods](mddocs/frontend/frontend-tdd.md#sessionfacade-orchestration) - submitToolInvocation, submitFinalResponse
- [FR Response Construction](mddocs/frontend/frontend-spec.md#fr-response-construction) - FR-017, FR-018, FR-019
