### PR TITLE
S6PR5: Integrate SmartBlobComponent for system instructions

### DIFF
--- a/frontend/src/app/features/session/session.component.ts
+++ b/frontend/src/app/features/session/session.component.ts
@@ -44,7 +44,7 @@ import {
   type ToolFormConfig,
 } from '../../ui/control-panel';
 import { EventStreamComponent } from '../../ui/event-stream';
-import { SplitPaneComponent } from '../../ui/shared';
+import { SmartBlobComponent, SplitPaneComponent } from '../../ui/shared';
 import { SimulationStore } from './simulation.store';
 
 /**
@@ -76,6 +76,7 @@ type SessionStatus = 'awaiting' | 'active' | 'completed';
     MatIconModule,
     MatButtonModule,
     SplitPaneComponent,
+    SmartBlobComponent,
     ControlPanelComponent,
     EventStreamComponent,
   ],
@@ -124,8 +125,8 @@ type SessionStatus = 'awaiting' | 'active' | 'completed';
                 id="instructions-content"
                 data-testid="instructions-content"
               >
-                @if (systemInstruction()) {
-                  <pre class="instructions-text">{{ systemInstructionText() }}</pre>
+                @if (systemInstructionText()) {
+                  <app-smart-blob [content]="systemInstructionText()" />
                 } @else {
                   <p class="no-instructions">No system instructions provided.</p>
                 }
@@ -287,18 +288,8 @@ type SessionStatus = 'awaiting' | 'active' | 'completed';
 
     .instructions-content {
       padding: 0 24px 16px 60px;
-      max-height: 200px;
+      max-height: 300px;
       overflow-y: auto;
-    }
-
-    .instructions-text {
-      margin: 0;
-      font-family: monospace;
-      font-size: 13px;
-      white-space: pre-wrap;
-      word-break: break-word;
-      color: var(--sys-on-surface);
-      line-height: 1.5;
     }
 
     .no-instructions {

--- a/mddocs/frontend/sprints/sprint6.md
+++ b/mddocs/frontend/sprints/sprint6.md
@@ -325,12 +325,12 @@ The existing `AnyObjectRenderer` provides a good template for implementation.
 - [SessionComponent](../../../frontend/src/app/features/session/session.component.ts) - Where to integrate
 
 **Acceptance Criteria**:
-- [ ] System instructions render using SmartBlobComponent
-- [ ] Markdown instructions display as formatted HTML by default
-- [ ] Users can toggle to RAW view to see original text
-- [ ] JSON-structured instructions (if any) can be viewed as tree
-- [ ] Works in both light and dark modes
-- [ ] Presubmit passes
+- [x] System instructions render using SmartBlobComponent
+- [x] Markdown instructions display as formatted HTML by default
+- [x] Users can toggle to RAW view to see original text
+- [x] JSON-structured instructions (if any) can be viewed as tree
+- [x] Works in both light and dark modes
+- [x] Presubmit passes
 
 ---
 


### PR DESCRIPTION
## Goal
Replace the raw `<pre>` rendering of system instructions with SmartBlobComponent to enable markdown rendering.

## Sprint Context
Sprint: 6
Sprint Plan: mddocs/frontend/sprints/sprint6.md

## Dependencies
- #197 (S6PR3: Move system instructions into event stream column)
- #198 (S6PR4: Create SmartBlobComponent)

## Acceptance Criteria
- [ ] System instructions render using SmartBlobComponent
- [ ] Markdown instructions display as formatted HTML by default
- [ ] Users can toggle to RAW view to see original text
- [ ] JSON-structured instructions (if any) can be viewed as tree
- [ ] Works in both light and dark modes
- [ ] Presubmit passes

## Background Reading
- [SmartBlobComponent Design](mddocs/frontend/frontend-tdd.md#smartblobcomponent)
- [SessionComponent](frontend/src/app/features/session/session.component.ts)

## Implementation Notes
- Replaced `<pre>` with `<app-smart-blob [content]="systemInstructionText()" />`
- Changed empty-check condition from `systemInstruction()` to `systemInstructionText()`
- Removed unused `.instructions-text` CSS class

🤖 Generated with [Claude Code](https://claude.ai/code)